### PR TITLE
feat: use new endpoints for import/export

### DIFF
--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -442,12 +442,12 @@ class SupersetClient:  # pylint: disable=too-few-public-methods
         """
         return self.update_resource("dashboard", dashboard_id, **kwargs)
 
-    def export_zip(self, resource: str, ids: List[int]) -> BytesIO:
+    def export_zip(self, resource: str, ids: Optional[List[int]] = None) -> BytesIO:
         """
         Export one or more of a resource.
         """
         url = self.baseurl / "api/v1" / resource / "export/"
-        params = {"q": prison.dumps(ids)}
+        params = {"q": prison.dumps(ids)} if ids is not None else {}
 
         session = self.auth.get_session()
         headers = self.auth.get_headers()
@@ -466,14 +466,17 @@ class SupersetClient:  # pylint: disable=too-few-public-methods
         """
         url = self.baseurl / "api/v1" / resource / "import/"
 
+        # the key used for ZIP uploads
+        key = "bundle" if resource == "assets" else "formData"
+
         session = self.auth.get_session()
         headers = self.auth.get_headers()
         headers["Referer"] = str(self.baseurl)
         headers["Accept"] = "application/json"
         response = session.post(
             url,
-            files=dict(formData=data),
-            data=dict(overwrite=json.dumps(overwrite)),
+            files={key: data},
+            data={"overwrite": json.dumps(overwrite)},
             headers=headers,
         )
 

--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -28,6 +28,7 @@ PASSWORD_MASK = "X" * 10
 
 
 resource_types = {
+    "assets": "assets",
     "chart": "Slice",
     "dashboard": "Dashboard",
     "database": "Database",
@@ -119,9 +120,7 @@ def native(  # pylint: disable=too-many-locals, too-many-arguments
 
                 contents[str("bundle" / relative_path)] = yaml.safe_dump(config)
 
-    # TODO (betodealmeida): use endpoint from https://github.com/apache/superset/pull/19220
-    for resource in ["database", "dataset", "chart", "dashboard"]:
-        import_resource(resource, contents, client, overwrite)
+    import_resource("assets", contents, client, overwrite)
 
 
 def prompt_for_passwords(path: Path, config: Dict[str, Any]) -> None:

--- a/src/preset_cli/constants.py
+++ b/src/preset_cli/constants.py
@@ -1,0 +1,6 @@
+"""
+Useful constants.
+"""
+
+
+METADATA_FILENAME = "metadata.yaml"

--- a/tests/cli/superset/export_test.py
+++ b/tests/cli/superset/export_test.py
@@ -5,7 +5,6 @@ Tests for the export command.
 
 from io import BytesIO
 from pathlib import Path
-from unittest import mock
 from zipfile import ZipFile
 
 import pytest
@@ -106,14 +105,7 @@ def test_export(mocker: MockerFixture, fs: FakeFilesystem) -> None:
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    export_resource.assert_has_calls(
-        [
-            mock.call("database", Path("/path/to/root"), client, False),
-            mock.call("dataset", Path("/path/to/root"), client, False),
-            mock.call("chart", Path("/path/to/root"), client, False),
-            mock.call("dashboard", Path("/path/to/root"), client, False),
-        ],
-    )
+    export_resource.assert_called_with("assets", root, client, False)
 
 
 def test_export_with_custom_auth(mocker: MockerFixture, fs: FakeFilesystem) -> None:
@@ -136,11 +128,4 @@ def test_export_with_custom_auth(mocker: MockerFixture, fs: FakeFilesystem) -> N
         obj={"AUTH": Auth()},
     )
     assert result.exit_code == 0
-    export_resource.assert_has_calls(
-        [
-            mock.call("database", Path("/path/to/root"), client, False),
-            mock.call("dataset", Path("/path/to/root"), client, False),
-            mock.call("chart", Path("/path/to/root"), client, False),
-            mock.call("dashboard", Path("/path/to/root"), client, False),
-        ],
-    )
+    export_resource.assert_called_with("assets", root, client, False)

--- a/tests/cli/superset/sync/native/command_test.py
+++ b/tests/cli/superset/sync/native/command_test.py
@@ -184,14 +184,7 @@ def test_native(mocker: MockerFixture, fs: FakeFilesystem) -> None:
         "bundle/databases/gsheets.yaml": yaml.dump(database_config),
         "bundle/datasets/gsheets/test.yaml": yaml.dump(dataset_config),
     }
-    import_resource.assert_has_calls(
-        [
-            mock.call("database", contents, client, False),
-            mock.call("dataset", contents, client, False),
-            mock.call("chart", contents, client, False),
-            mock.call("dashboard", contents, client, False),
-        ],
-    )
+    import_resource.assert_called_with("assets", contents, client, False)
 
 
 def test_native_external_url(mocker: MockerFixture, fs: FakeFilesystem) -> None:
@@ -252,14 +245,7 @@ def test_native_external_url(mocker: MockerFixture, fs: FakeFilesystem) -> None:
         "bundle/databases/gsheets.yaml": yaml.dump(database_config),
         "bundle/datasets/gsheets/test.yaml": yaml.dump(dataset_config),
     }
-    import_resource.assert_has_calls(
-        [
-            mock.call("database", contents, client, False),
-            mock.call("dataset", contents, client, False),
-            mock.call("chart", contents, client, False),
-            mock.call("dashboard", contents, client, False),
-        ],
-    )
+    import_resource.assert_called_with("assets", contents, client, False)
 
 
 def test_load_user_modules(mocker: MockerFixture, fs: FakeFilesystem) -> None:


### PR DESCRIPTION
Use endpoints introduced in https://github.com/apache/superset/pull/19220.

We still need to fix auth upstream before merging this (https://github.com/apache/superset/pull/19656).