### PR TITLE
feat: add env_var to profiles loading

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/databases.py
+++ b/src/preset_cli/cli/superset/sync/dbt/databases.py
@@ -7,10 +7,11 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from jinja2 import Template
 from yarl import URL
 
 from preset_cli.api.clients.superset import SupersetClient
-from preset_cli.cli.superset.sync.dbt.lib import build_sqlalchemy_params
+from preset_cli.cli.superset.sync.dbt.lib import build_sqlalchemy_params, env_var
 from preset_cli.exceptions import DatabaseNotFoundError
 
 _logger = logging.getLogger(__name__)
@@ -31,7 +32,9 @@ def sync_database(  # pylint: disable=too-many-locals, too-many-arguments
     base_url = URL(external_url_prefix) if external_url_prefix else None
 
     with open(profiles_path, encoding="utf-8") as input_:
-        profiles = yaml.load(input_, Loader=yaml.SafeLoader)
+        template = Template(input_.read())
+        content = template.render(env_var=env_var)
+        profiles = yaml.load(content, Loader=yaml.SafeLoader)
 
     if project_name not in profiles:
         raise Exception(f"Project {project_name} not found in {profiles_path}")

--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -3,7 +3,8 @@ Helper functions.
 """
 
 import json
-from typing import Any, Dict
+import os
+from typing import Any, Dict, Optional
 
 from sqlalchemy.engine.url import URL
 
@@ -89,3 +90,14 @@ def build_bigquery_sqlalchemy_params(target: Dict[str, Any]) -> Dict[str, Any]:
         )
 
     return parameters
+
+
+def env_var(var: str, default: Optional[str] = None) -> str:
+    """
+    Simplified version of dbt's ``env_var``.
+
+    We need this to load the profile with secrets.
+    """
+    if var not in os.environ and not default:
+        raise Exception(f"Env var required but not provided: '{var}'")
+    return os.environ.get(var, default or "")

--- a/tests/cli/superset/sync/dbt/lib_test.py
+++ b/tests/cli/superset/sync/dbt/lib_test.py
@@ -8,7 +8,7 @@ import json
 import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
 
-from preset_cli.cli.superset.sync.dbt.lib import build_sqlalchemy_params
+from preset_cli.cli.superset.sync.dbt.lib import build_sqlalchemy_params, env_var
 
 
 def test_build_sqlalchemy_params_postgres() -> None:
@@ -99,3 +99,16 @@ def test_build_sqlalchemy_params_unsupported() -> None:
         "an issue at https://github.com/preset-io/backend-sdk/issues/new?"
         "labels=enhancement&title=Backend+for+mysql."
     )
+
+
+def test_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Test the ``env_var`` implementation.
+    """
+    monkeypatch.setenv("MY_USER", "Nanna")
+
+    assert env_var("MY_USER") == "Nanna"
+    assert env_var("YOUR_USER", "Jane Doe") == "Jane Doe"
+    with pytest.raises(Exception) as excinfo:
+        env_var("YOUR_USER")
+    assert str(excinfo.value) == "Env var required but not provided: 'YOUR_USER'"


### PR DESCRIPTION
This allows us to load dbt profiles that use `env_var` for secrets.