### PR TITLE
fix: dbt profile loading

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -2,10 +2,14 @@
 Helper functions.
 """
 
+import ast
 import json
 import os
-from typing import Any, Dict, Optional
+from pathlib import Path
+from typing import Any, Dict, Optional, TypedDict, Union
 
+import yaml
+from jinja2 import Environment
 from sqlalchemy.engine.url import URL
 
 
@@ -101,3 +105,70 @@ def env_var(var: str, default: Optional[str] = None) -> str:
     if var not in os.environ and not default:
         raise Exception(f"Env var required but not provided: '{var}'")
     return os.environ.get(var, default or "")
+
+
+def as_number(value: str) -> Union[int, float]:
+    """
+    Simplified version of dbt's ``as_number``.
+    """
+    try:
+        return int(value)
+    except ValueError:
+        return float(value)
+
+
+class Target(TypedDict):
+    """
+    Information about the warehouse connection.
+    """
+
+    profile_name: str
+    name: str
+    schema: str
+    type: str
+    threads: int
+
+
+def load_profiles(path: Path, project_name: str, target_name: str) -> Dict[str, Any]:
+    """
+    Load the file and apply Jinja2 templating.
+    """
+    with open(path, encoding="utf-8") as input_:
+        profiles = yaml.load(input_, Loader=yaml.SafeLoader)
+
+    if project_name not in profiles:
+        raise Exception(f"Project {project_name} not found in {path}")
+    project = profiles[project_name]
+    outputs = project["outputs"]
+    if target_name not in outputs:
+        raise Exception(f"Target {target_name} not found in the outputs of {path}")
+    target = outputs[target_name]
+
+    env = Environment()
+    env.filters["as_bool"] = bool
+    env.filters["as_native"] = ast.literal_eval
+    env.filters["as_number"] = as_number
+    env.filters["as_text"] = str
+
+    context = {
+        "env_var": env_var,
+        "project_name": project_name,
+        "target": target,
+    }
+
+    def apply_templating(config: Any) -> Any:
+        """
+        Apply Jinja2 templating to dictionary values recursively.
+        """
+        if isinstance(config, dict):
+            for key, value in config.items():
+                config[key] = apply_templating(value)
+        elif isinstance(config, list):
+            config = [apply_templating(el) for el in config]
+        elif isinstance(config, str):
+            template = env.from_string(config)
+            config = yaml.safe_load(template.render(**context))
+
+        return config
+
+    return apply_templating(profiles)


### PR DESCRIPTION
We were loading the dbt profile incorrectly by first apply the Jinja2 templating then loading the YAML. But the dbt profile is valid YAML with Jinja2 as values, so the order must be reversed — first load the YAML, then apply Jinja2 to the leaves.

I also implemented a few filters that dbt provides:

- `as_bool`
- `as_number`
- `as_native`
- `as_text`

As well as adding `project_name` and `target` to the template context.