### PR TITLE
feat: allow passing dataset metadata

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -104,6 +104,7 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches
             "is_managed_externally": disallow_edits,
             "metrics": [],
         }
+        update.update(config.get("meta", {}).get("superset", {}))
         if base_url:
             fragment = "!/{resource_type}/{unique_id}".format(**config)
             update["external_url"] = str(base_url.with_fragment(fragment))


### PR DESCRIPTION
Allow passing arbitrary metadata to datasets from models:

```yaml
models:
  - name: customers
    description: One record per customer
    meta:
      superset:
        cache_timeout: 600
    columns:
      - name: customer_id
        description: Primary key
        tests:
          - unique
          - not_null
      - name: first_order_date
        description: NULL when a customer has not yet placed an order.
```