### PR TITLE
feat: dbt selectors for sync

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -522,12 +522,15 @@ class ModelSchema(PostelSchema):
     Schema for a model.
     """
 
+    depends_on = fields.List(fields.String(), data_key="dependsOn")
+    children = fields.List(fields.String(), data_key="childrenL1")
     database = fields.String()
     schema = fields.String()
     description = fields.String()
     meta = fields.Raw()
     name = fields.String()
     unique_id = fields.String(data_key="uniqueId")
+    tags = fields.List(fields.String())
 
 
 class FilterSchema(PostelSchema):
@@ -648,11 +651,14 @@ class DBTClient:  # pylint: disable=too-few-public-methods
             query ($jobId: Int!) {
                 models(jobId: $jobId) {
                     uniqueId
+                    dependsOn
+                    childrenL1
                     name
                     database
                     schema
                     description
                     meta
+                    tags
                 }
             }
         """

--- a/tests/cli/superset/sync/dbt/command_test.py
+++ b/tests/cli/superset/sync/dbt/command_test.py
@@ -80,6 +80,7 @@ def test_dbt_core(mocker: MockerFixture, fs: FakeFilesystem) -> None:
             "name": "messages_channels",
             "schema": "public",
             "unique_id": "model.superset_examples.messages_channels",
+            "tags": [],
         },
     ]
     metrics = [
@@ -169,6 +170,7 @@ def test_dbt(mocker: MockerFixture, fs: FakeFilesystem) -> None:
             "name": "messages_channels",
             "schema": "public",
             "unique_id": "model.superset_examples.messages_channels",
+            "tags": [],
         },
     ]
     metrics = [

--- a/tests/cli/superset/sync/dbt/lib_test.py
+++ b/tests/cli/superset/sync/dbt/lib_test.py
@@ -249,11 +249,22 @@ def test_filter_models() -> None:
     }
     models: List[ModelSchema] = [one, two, three]  # type: ignore
 
-    assert filter_models(models, "one") == [one]
-    assert filter_models(models, "one+") == [one, two]
-    assert filter_models(models, "+two") == [two, one, three]
-    assert filter_models(models, "tag:test") == [one]
-    assert filter_models(models, "@one") == [one, two, three]
+    assert {model["name"] for model in filter_models(models, "one")} == {"one"}
+    assert {model["name"] for model in filter_models(models, "one+")} == {
+        "one",
+        "two",
+    }
+    assert {model["name"] for model in filter_models(models, "+two")} == {
+        "one",
+        "two",
+        "three",
+    }
+    assert {model["name"] for model in filter_models(models, "tag:test")} == {"one"}
+    assert {model["name"] for model in filter_models(models, "@one")} == {
+        "one",
+        "two",
+        "three",
+    }
 
     with pytest.raises(NotImplementedError) as excinfo:
         filter_models(models, "invalid")
@@ -298,10 +309,28 @@ def test_filter_models_seen() -> None:
     }
     models: List[ModelSchema] = [one, two, three, four]  # type: ignore
 
-    assert filter_models(models, "+four") == [four, two, three, one]
-    assert filter_models(models, "one+") == [one, two, three, four]
-    assert filter_models(models, "1+four") == [four, two, three]
-    assert filter_models(models, "one+1") == [one, two, three]
+    assert {model["name"] for model in filter_models(models, "+four")} == {
+        "one",
+        "two",
+        "three",
+        "four",
+    }
+    assert {model["name"] for model in filter_models(models, "one+")} == {
+        "one",
+        "two",
+        "three",
+        "four",
+    }
+    assert {model["name"] for model in filter_models(models, "1+four")} == {
+        "two",
+        "three",
+        "four",
+    }
+    assert {model["name"] for model in filter_models(models, "one+1")} == {
+        "one",
+        "two",
+        "three",
+    }
 
 
 def test_apply_select() -> None:
@@ -331,7 +360,18 @@ def test_apply_select() -> None:
     }
     models: List[ModelSchema] = [one, two, three]  # type: ignore
 
-    assert apply_select(models, ("one", "two")) == [one, two]
-    assert apply_select(models, ("+two+",)) == [one, two, three]
-    assert apply_select(models, ("+two+,tag:test",)) == [one]
-    assert apply_select(models, ("tag:test,+two+",)) == [one]
+    assert {model["name"] for model in apply_select(models, ("one", "two"))} == {
+        "one",
+        "two",
+    }
+    assert {model["name"] for model in apply_select(models, ("+two+",))} == {
+        "one",
+        "two",
+        "three",
+    }
+    assert {model["name"] for model in apply_select(models, ("+two+,tag:test",))} == {
+        "one",
+    }
+    assert {model["name"] for model in apply_select(models, ("tag:test,+two+",))} == {
+        "one",
+    }


### PR DESCRIPTION
Allow using the [node selection syntax(https://docs.getdbt.com/reference/node-selection/syntax) to choose which models should be synced.

Currently supports tags, plus, n-plus, and at operators.