### PR TITLE
feat: export ownership

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,7 @@ The following commands are currently available:
 - ``preset-cli auth``: store authentication credentials.
 - ``preset-cli superset sql``: run SQL interactively or programmatically against an analytical database.
 - ``preset-cli superset export-assets``: export resources (databases, datasets, charts, dashboards) into a directory as YAML files.
+- ``preset-cli superset export-ownership``: export resource ownership (UUID -> email) into a YAML file.
 - ``preset-cli superset export-rls``: export RLS rules into a YAML file.
 - ``preset-cli superset export-users``: export users (name, username, email, roles) into a YAML file.
 - ``preset-cli superset sync native``: synchronize the workspace from a directory of templated configuration files.
@@ -428,3 +429,8 @@ Exporting RLS rules
 ~~~~~~~~~~~~~~~~~~~
 
 The ``preset-cli superset export-rls`` command can be used to export a list of RLS rules. Currently there's no way to import this into a workspace, but work is in progress.
+
+Exporting ownership
+~~~~~~~~~~~~~~~~~~~
+
+The ``preset-cli superset export-ownership`` command generates a YAML file with information about ownership of different resources. The file maps resource UUIDs to user email address, and in the future will be used to recreate ownership on a different instance of Superset.

--- a/src/preset_cli/cli/superset/main.py
+++ b/src/preset_cli/cli/superset/main.py
@@ -7,7 +7,12 @@ import click
 from yarl import URL
 
 from preset_cli.auth.main import UsernamePasswordAuth
-from preset_cli.cli.superset.export import export_assets, export_rls, export_users
+from preset_cli.cli.superset.export import (
+    export_assets,
+    export_ownership,
+    export_rls,
+    export_users,
+)
 from preset_cli.cli.superset.sql import sql
 from preset_cli.cli.superset.sync.main import sync
 
@@ -49,6 +54,7 @@ superset_cli.add_command(export_assets)
 superset_cli.add_command(export_assets, name="export")  # for backwards compatibility
 superset_cli.add_command(export_users)
 superset_cli.add_command(export_rls)
+superset_cli.add_command(export_ownership)
 
 
 @click.group()

--- a/tests/cli/superset/main_test.py
+++ b/tests/cli/superset/main_test.py
@@ -114,6 +114,7 @@ Options:
 Commands:
   export
   export-assets
+  export-ownership
   export-rls
   export-users
   sql


### PR DESCRIPTION
Create a mapping between resource (dataset, chart, dashboard) UUID and owner emails:

```bash
$ superset-cli -u admin -p admin http://localhost:8088/ export-ownership
$ cat ownership.yaml
dataset:
- name: test_table
  owners:
  - admin@dealmeida.net
  uuid: e4e6a14b-c3e8-4fdf-a850-183ba6ce15e0
```