### PR TITLE
feat: import ownership information

### DIFF
--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -785,3 +785,19 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
                 "uuid": uuids[resource["id"]],
                 "owners": [emails[owner["id"]] for owner in resource.get("owners", [])],
             }
+
+    def import_ownership(
+        self,
+        resource_name: str,
+        ownership: List[Dict[str, Any]],
+    ) -> None:
+        """
+        Import ownership on resources.
+        """
+        user_ids = {user["email"]: user["id"] for user in self.export_users()}
+        resource_ids = {str(v): k for k, v in self.get_uuids(resource_name).items()}
+
+        for item in ownership:
+            resource_id = resource_ids[item["uuid"]]
+            owner_ids = [user_ids[email] for email in item["owners"]]
+            self.update_resource(resource_name, resource_id, owners=owner_ids)

--- a/src/preset_cli/cli/superset/import_.py
+++ b/src/preset_cli/cli/superset/import_.py
@@ -28,3 +28,24 @@ def import_rls(ctx: click.core.Context, path: str) -> None:
         config = yaml.load(input_, Loader=yaml.SafeLoader)
         for rls in config:
             client.import_rls(rls)
+
+
+@click.command()
+@click.argument(
+    "path",
+    type=click.Path(resolve_path=True),
+    default="ownership.yaml",
+)
+@click.pass_context
+def import_ownership(ctx: click.core.Context, path: str) -> None:
+    """
+    Import resource ownership from a YAML file.
+    """
+    auth = ctx.obj["AUTH"]
+    url = URL(ctx.obj["INSTANCE"])
+    client = SupersetClient(url, auth)
+
+    with open(path, encoding="utf-8") as input_:
+        config = yaml.load(input_, Loader=yaml.SafeLoader)
+        for resource_name, ownership in config.items():
+            client.import_ownership(resource_name, ownership)

--- a/src/preset_cli/cli/superset/main.py
+++ b/src/preset_cli/cli/superset/main.py
@@ -13,7 +13,7 @@ from preset_cli.cli.superset.export import (
     export_rls,
     export_users,
 )
-from preset_cli.cli.superset.import_ import import_rls
+from preset_cli.cli.superset.import_ import import_ownership, import_rls
 from preset_cli.cli.superset.sql import sql
 from preset_cli.cli.superset.sync.main import sync
 from preset_cli.cli.superset.sync.native.command import native
@@ -58,6 +58,7 @@ superset_cli.add_command(export_users)
 superset_cli.add_command(export_rls)
 superset_cli.add_command(export_ownership)
 superset_cli.add_command(import_rls)
+superset_cli.add_command(import_ownership)
 superset_cli.add_command(native, name="import-assets")
 
 

--- a/tests/cli/superset/import_test.py
+++ b/tests/cli/superset/import_test.py
@@ -41,3 +41,32 @@ def test_import_rls(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     assert result.exit_code == 0
 
     client.import_rls.assert_called_with(rls[0])
+
+
+def test_import_ownership(mocker: MockerFixture, fs: FakeFilesystem) -> None:
+    """
+    Test the ``import_ownership`` command.
+    """
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+    SupersetClient = mocker.patch("preset_cli.cli.superset.import_.SupersetClient")
+    client = SupersetClient()
+    ownership = {
+        "dataset": [
+            {
+                "name": "test_table",
+                "owners": ["admin@example.com"],
+                "uuid": "e4e6a14b-c3e8-4fdf-a850-183ba6ce15e0",
+            },
+        ],
+    }
+    fs.create_file("ownership.yaml", contents=yaml.dump(ownership))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        superset_cli,
+        ["https://superset.example.org/", "import-ownership"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    client.import_ownership.assert_called_with("dataset", ownership["dataset"])

--- a/tests/cli/superset/main_test.py
+++ b/tests/cli/superset/main_test.py
@@ -118,6 +118,7 @@ Commands:
   export-rls
   export-users
   import-assets
+  import-ownership
   import-rls
   sql
   sync


### PR DESCRIPTION
Allow updating ownership of resources (datasets, charts, dashboards) based on an export from https://github.com/preset-io/backend-sdk/pull/58.