### PR TITLE
chore: add debug logging to all API requests

### DIFF
--- a/src/preset_cli/cli/superset/main.py
+++ b/src/preset_cli/cli/superset/main.py
@@ -18,6 +18,7 @@ from preset_cli.cli.superset.import_ import import_ownership, import_rls, import
 from preset_cli.cli.superset.sql import sql
 from preset_cli.cli.superset.sync.main import sync
 from preset_cli.cli.superset.sync.native.command import native
+from preset_cli.lib import setup_logging
 
 
 @click.group()
@@ -32,16 +33,20 @@ from preset_cli.cli.superset.sync.native.command import native
     hide_input=True,
     help="Password (leave empty for prompt)",
 )
+@click.option("--loglevel", default="INFO")
 @click.pass_context
 def superset_cli(
     ctx: click.core.Context,
     instance: str,
-    username: str = "admin",
-    password: str = "admin",
+    username: str,
+    password: str,
+    loglevel: str,
 ):
     """
     An Apache Superset CLI.
     """
+    setup_logging(loglevel)
+
     ctx.ensure_object(dict)
 
     ctx.obj["INSTANCE"] = instance

--- a/tests/api/clients/preset_test.py
+++ b/tests/api/clients/preset_test.py
@@ -3,6 +3,7 @@ Tests for ``preset_cli.api.clients.preset``.
 """
 
 import pytest
+from pytest_mock import MockerFixture
 from requests_mock.mocker import Mocker
 from yarl import URL
 
@@ -10,16 +11,20 @@ from preset_cli.api.clients.preset import PresetClient
 from preset_cli.auth.main import Auth
 
 
-def test_preset_client_get_teams(requests_mock: Mocker) -> None:
+def test_preset_client_get_teams(mocker: MockerFixture, requests_mock: Mocker) -> None:
     """
     Test the ``get_teams`` method.
     """
+    _logger = mocker.patch("preset_cli.api.clients.preset._logger")
     requests_mock.get("https://ws.preset.io/api/v1/teams/", json={"payload": [1, 2, 3]})
 
     auth = Auth()
     client = PresetClient("https://ws.preset.io/", auth)
     teams = client.get_teams()
     assert teams == [1, 2, 3]
+    _logger.debug.assert_called_with(
+        "GET %s", URL("https://ws.preset.io/api/v1/teams/")
+    )
 
 
 def test_preset_client_get_workspaces(requests_mock: Mocker) -> None:


### PR DESCRIPTION
This sets explicit logging for API requests.

Alternatively we could set the debug level in the `urllib3` library directly (see https://requests.readthedocs.io/en/latest/api/?highlight=logging#api-changes), but I tried and it's too verbose.