### PR TITLE
feat: allow specifying asset types

### DIFF
--- a/src/preset_cli/cli/superset/export.py
+++ b/src/preset_cli/cli/superset/export.py
@@ -4,6 +4,7 @@ A command to export Superset resources into a directory.
 
 from collections import defaultdict
 from pathlib import Path
+from typing import Tuple
 from zipfile import ZipFile
 
 import click
@@ -26,10 +27,16 @@ assert JINJA2_OPEN_MARKER != JINJA2_CLOSE_MARKER
     default=False,
     help="Overwrite existing resources",
 )
+@click.option(
+    "--asset-type",
+    help="Asset type",
+    multiple=True,
+)
 @click.pass_context
 def export_assets(  # pylint: disable=too-many-locals
     ctx: click.core.Context,
     directory: str,
+    asset_type: Tuple[str, ...],
     overwrite: bool = False,
 ) -> None:
     """
@@ -39,9 +46,11 @@ def export_assets(  # pylint: disable=too-many-locals
     url = URL(ctx.obj["INSTANCE"])
     client = SupersetClient(url, auth)
     root = Path(directory)
+    asset_types = set(asset_type)
 
     for resource_name in ["database", "dataset", "chart", "dashboard"]:
-        export_resource(resource_name, root, client, overwrite)
+        if not asset_types or resource_name in asset_types:
+            export_resource(resource_name, root, client, overwrite)
 
 
 def export_resource(

--- a/tests/cli/superset/export_test.py
+++ b/tests/cli/superset/export_test.py
@@ -150,6 +150,42 @@ def test_export_assets(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     )
 
 
+def test_export_assets_by_type(mocker: MockerFixture, fs: FakeFilesystem) -> None:
+    """
+    Test the ``export_assets`` command.
+    """
+    # root must exist for command to succeed
+    root = Path("/path/to/root")
+    fs.create_dir(root)
+
+    SupersetClient = mocker.patch("preset_cli.cli.superset.export.SupersetClient")
+    client = SupersetClient()
+    export_resource = mocker.patch("preset_cli.cli.superset.export.export_resource")
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        superset_cli,
+        [
+            "https://superset.example.org/",
+            "export",
+            "/path/to/root",
+            "--asset-type",
+            "dashboard",
+            "--asset-type",
+            "dataset",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    export_resource.assert_has_calls(
+        [
+            mock.call("dataset", Path("/path/to/root"), client, False),
+            mock.call("dashboard", Path("/path/to/root"), client, False),
+        ],
+    )
+
+
 def test_export_with_custom_auth(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     """
     Test the ``export`` command.

--- a/tests/cli/superset/main_test.py
+++ b/tests/cli/superset/main_test.py
@@ -135,8 +135,9 @@ Commands:
         == """Usage: superset export [OPTIONS] DIRECTORY
 
 Options:
-  --overwrite  Overwrite existing resources
-  --help       Show this message and exit.
+  --overwrite        Overwrite existing resources
+  --asset-type TEXT  Asset type
+  --help             Show this message and exit.
 """
     )
 


### PR DESCRIPTION
```bash
$ superset-cli http://localhost:8088/ export ~/export --asset-type=dashboard --asset-type=chart
```

Will export only charts and dashboards.