### PR TITLE
feat: export resources by ID

### DIFF
--- a/src/preset_cli/cli/main.py
+++ b/src/preset_cli/cli/main.py
@@ -21,23 +21,9 @@ from preset_cli.auth.lib import (
 )
 from preset_cli.auth.main import Auth
 from preset_cli.cli.superset.main import superset
-from preset_cli.lib import setup_logging
+from preset_cli.lib import setup_logging, split_comma
 
 _logger = logging.getLogger(__name__)
-
-
-def split_comma(  # pylint: disable=unused-argument
-    ctx: click.core.Context,
-    param: str,
-    value: Optional[str],
-) -> List[str]:
-    """
-    Split CLI option into multiple values.
-    """
-    if value is None:
-        return []
-
-    return [option.strip() for option in value.split(",")]
 
 
 def get_status_icon(status: str) -> str:

--- a/src/preset_cli/cli/superset/main.py
+++ b/src/preset_cli/cli/superset/main.py
@@ -37,7 +37,7 @@ from preset_cli.lib import setup_logging
 )
 @click.option("--loglevel", default="INFO")
 @click.pass_context
-def superset_cli(
+def superset_cli(  # pylint: disable=too-many-arguments
     ctx: click.core.Context,
     instance: str,
     jwt_token: Optional[str],

--- a/src/preset_cli/lib.py
+++ b/src/preset_cli/lib.py
@@ -5,8 +5,9 @@ Basic helper functions.
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Optional, cast
 
+import click
 from requests import Response
 from rich.logging import RichHandler
 
@@ -96,3 +97,17 @@ def validate_response(response: Response) -> None:
 
     _logger.error(message)
     raise SupersetError(errors=errors)
+
+
+def split_comma(  # pylint: disable=unused-argument
+    ctx: click.core.Context,
+    param: str,
+    value: Optional[str],
+) -> List[str]:
+    """
+    Split CLI option into multiple values.
+    """
+    if value is None:
+        return []
+
+    return [option.strip() for option in value.split(",")]

--- a/tests/api/clients/preset_test.py
+++ b/tests/api/clients/preset_test.py
@@ -23,7 +23,8 @@ def test_preset_client_get_teams(mocker: MockerFixture, requests_mock: Mocker) -
     teams = client.get_teams()
     assert teams == [1, 2, 3]
     _logger.debug.assert_called_with(
-        "GET %s", URL("https://ws.preset.io/api/v1/teams/")
+        "GET %s",
+        URL("https://ws.preset.io/api/v1/teams/"),
     )
 
 

--- a/tests/cli/main_test.py
+++ b/tests/cli/main_test.py
@@ -13,12 +13,8 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest_mock import MockerFixture
 from yarl import URL
 
-from preset_cli.cli.main import (
-    get_status_icon,
-    parse_selection,
-    preset_cli,
-    split_comma,
-)
+from preset_cli.cli.main import get_status_icon, parse_selection, preset_cli
+from preset_cli.lib import split_comma
 
 
 def test_split_comma(mocker: MockerFixture) -> None:

--- a/tests/cli/superset/main_test.py
+++ b/tests/cli/superset/main_test.py
@@ -135,9 +135,13 @@ Commands:
         == """Usage: superset export [OPTIONS] DIRECTORY
 
 Options:
-  --overwrite        Overwrite existing resources
-  --asset-type TEXT  Asset type
-  --help             Show this message and exit.
+  --overwrite           Overwrite existing resources
+  --asset-type TEXT     Asset type
+  --database-ids TEXT   Comma separated list of database IDs to export
+  --dataset-ids TEXT    Comma separated list of dataset IDs to export
+  --chart-ids TEXT      Comma separated list of chart IDs to export
+  --dashboard-ids TEXT  Comma separated list of dashboard IDs to export
+  --help                Show this message and exit.
 """
     )
 


### PR DESCRIPTION
Allow specifying resource ID when exporting. Eg:

```bash
$ superset-cli http://localhost:8088/ export --asset-type=dashboard --dashboard-ids=1,2,3
```

Will only export dashboards with IDs 1, 2, and 3.