### PR TITLE
chore: improve export by ID

### DIFF
--- a/src/preset_cli/cli/superset/export.py
+++ b/src/preset_cli/cli/superset/export.py
@@ -77,7 +77,7 @@ def export_assets(  # pylint: disable=too-many-locals, too-many-arguments
         "chart": {int(id_) for id_ in chart_ids},
         "dashboard": {int(id_) for id_ in dashboard_ids},
     }
-    ids_requested = database_ids or dataset_ids or chart_ids or dashboard_ids
+    ids_requested = any([database_ids, dataset_ids, chart_ids, dashboard_ids])
 
     for resource_name in ["database", "dataset", "chart", "dashboard"]:
         if (not asset_types or resource_name in asset_types) and (

--- a/src/preset_cli/cli/superset/export.py
+++ b/src/preset_cli/cli/superset/export.py
@@ -77,18 +77,29 @@ def export_assets(  # pylint: disable=too-many-locals, too-many-arguments
         "chart": {int(id_) for id_ in chart_ids},
         "dashboard": {int(id_) for id_ in dashboard_ids},
     }
+    ids_requested = database_ids or dataset_ids or chart_ids or dashboard_ids
 
     for resource_name in ["database", "dataset", "chart", "dashboard"]:
-        if not asset_types or resource_name in asset_types:
-            export_resource(resource_name, ids[resource_name], root, client, overwrite)
+        if (not asset_types or resource_name in asset_types) and (
+            ids[resource_name] or not ids_requested
+        ):
+            export_resource(
+                resource_name,
+                ids[resource_name],
+                root,
+                client,
+                overwrite,
+                skip_related=not ids_requested,
+            )
 
 
-def export_resource(
+def export_resource(  # pylint: disable=too-many-arguments
     resource_name: str,
     requested_ids: Set[int],
     root: Path,
     client: SupersetClient,
     overwrite: bool,
+    skip_related: bool = True,
 ) -> None:
     """
     Export a given resource and unzip it in a directory.
@@ -108,8 +119,7 @@ def export_resource(
         }
 
     for file_name, file_contents in contents.items():
-        # skip related files
-        if not file_name.startswith(resource_name):
+        if skip_related and not file_name.startswith(resource_name):
             continue
 
         target = root / file_name

--- a/tests/cli/superset/export_test.py
+++ b/tests/cli/superset/export_test.py
@@ -167,10 +167,33 @@ def test_export_assets(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     assert result.exit_code == 0
     export_resource.assert_has_calls(
         [
-            mock.call("database", set(), Path("/path/to/root"), client, False),
-            mock.call("dataset", set(), Path("/path/to/root"), client, False),
-            mock.call("chart", set(), Path("/path/to/root"), client, False),
-            mock.call("dashboard", set(), Path("/path/to/root"), client, False),
+            mock.call(
+                "database",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                skip_related=True,
+            ),
+            mock.call(
+                "dataset",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                skip_related=True,
+            ),
+            mock.call(
+                "chart", set(), Path("/path/to/root"), client, False, skip_related=True,
+            ),
+            mock.call(
+                "dashboard",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                skip_related=True,
+            ),
         ],
     )
 
@@ -203,10 +226,14 @@ def test_export_assets_by_id(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     assert result.exit_code == 0
     export_resource.assert_has_calls(
         [
-            mock.call("database", {1, 2, 3}, Path("/path/to/root"), client, False),
-            mock.call("dataset", set(), Path("/path/to/root"), client, False),
-            mock.call("chart", set(), Path("/path/to/root"), client, False),
-            mock.call("dashboard", set(), Path("/path/to/root"), client, False),
+            mock.call(
+                "database",
+                {1, 2, 3},
+                Path("/path/to/root"),
+                client,
+                False,
+                skip_related=False,
+            ),
         ],
     )
 
@@ -241,8 +268,22 @@ def test_export_assets_by_type(mocker: MockerFixture, fs: FakeFilesystem) -> Non
     assert result.exit_code == 0
     export_resource.assert_has_calls(
         [
-            mock.call("dataset", set(), Path("/path/to/root"), client, False),
-            mock.call("dashboard", set(), Path("/path/to/root"), client, False),
+            mock.call(
+                "dataset",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                skip_related=True,
+            ),
+            mock.call(
+                "dashboard",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                skip_related=True,
+            ),
         ],
     )
 
@@ -269,10 +310,33 @@ def test_export_with_custom_auth(mocker: MockerFixture, fs: FakeFilesystem) -> N
     assert result.exit_code == 0
     export_resource.assert_has_calls(
         [
-            mock.call("database", set(), Path("/path/to/root"), client, False),
-            mock.call("dataset", set(), Path("/path/to/root"), client, False),
-            mock.call("chart", set(), Path("/path/to/root"), client, False),
-            mock.call("dashboard", set(), Path("/path/to/root"), client, False),
+            mock.call(
+                "database",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                skip_related=True,
+            ),
+            mock.call(
+                "dataset",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                skip_related=True,
+            ),
+            mock.call(
+                "chart", set(), Path("/path/to/root"), client, False, skip_related=True,
+            ),
+            mock.call(
+                "dashboard",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                skip_related=True,
+            ),
         ],
     )
 

--- a/tests/cli/superset/export_test.py
+++ b/tests/cli/superset/export_test.py
@@ -184,7 +184,12 @@ def test_export_assets(mocker: MockerFixture, fs: FakeFilesystem) -> None:
                 skip_related=True,
             ),
             mock.call(
-                "chart", set(), Path("/path/to/root"), client, False, skip_related=True,
+                "chart",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                skip_related=True,
             ),
             mock.call(
                 "dashboard",
@@ -327,7 +332,12 @@ def test_export_with_custom_auth(mocker: MockerFixture, fs: FakeFilesystem) -> N
                 skip_related=True,
             ),
             mock.call(
-                "chart", set(), Path("/path/to/root"), client, False, skip_related=True,
+                "chart",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                skip_related=True,
             ),
             mock.call(
                 "dashboard",


### PR DESCRIPTION
This PR introduces a few changes to the `superset export` command. First, if IDs are specified for any resource type, then all assets are exported by ID. The command:

```bash
superset-cli export --database-ids=1,2
```

Will export only databases with ID 1 and 2, and no datasets, charts, nor dashboards will be exported. **Before:** this would export databases with ID 1 and 2, but also **all** datasets, charts, and dashboards.

Second, when an ID is specified, related assets are also exported. The command:

```bash
superset-cli export --dashboard-ids=1 --asset-type=dashboard
```

Will export dashboard with ID 1, but also all its associated charts, datasets, and databases. **Before:** this would export only the dashboard with ID 1, but not export associated resources.

IDs for multiple resource types can be specified:

```bash
superset-cli export --dashboard-ids=1 --chart-ids=42
```

Will export dashboard with ID 1 and related assets, as well as chart with ID 42 and related assets.