### PR TITLE
feat: sync user roles

### DIFF
--- a/src/preset_cli/api/clients/preset.py
+++ b/src/preset_cli/api/clients/preset.py
@@ -57,6 +57,20 @@ class PresetClient:  # pylint: disable=too-few-public-methods
 
         return teams
 
+    def get_team_members(self, team_name: str) -> List[Any]:
+        """
+        Retrieve all users for a given team.
+        """
+        url = self.baseurl / "api/v1/teams" / team_name / "memberships"
+        _logger.debug("GET %s", url)
+        response = self.session.get(url)
+        validate_response(response)
+
+        payload = response.json()
+        users = payload["payload"]
+
+        return users
+
     def get_workspaces(self, team_name: str) -> List[Any]:
         """
         Retrieve all workspaces for a given team.
@@ -183,3 +197,34 @@ class PresetClient:  # pylint: disable=too-few-public-methods
                 _logger.debug("POST %s\n%s", url, json.dumps(payload, indent=4))
                 response = self.session.post(url, json=payload)
                 validate_response(response)
+
+    def change_team_role(self, team_name: str, user_id: int, role_id: int) -> None:
+        """
+        Change the team role of a given user.
+        """
+        url = self.baseurl / "api/v1/teams" / team_name / "memberships" / str(user_id)
+        payload = {"team_role_id": role_id}
+        _logger.debug("PATCH %s\n%s", url, json.dumps(payload, indent=4))
+        self.session.patch(url, json=payload)
+
+    def change_workspace_role(
+        self,
+        team_name: str,
+        workspace_id: int,
+        user_id: int,
+        role_identifier: str,
+    ) -> None:
+        """
+        Change the workspace role of a given user.
+        """
+        url = (
+            self.baseurl
+            / "api/v1/teams"
+            / team_name
+            / "workspaces"
+            / str(workspace_id)
+            / "membership"
+        )
+        payload = {"role_identifier": role_identifier, "user_id": user_id}
+        _logger.debug("PUT %s\n%s", url, json.dumps(payload, indent=4))
+        self.session.put(url, json=payload)

--- a/src/preset_cli/cli/main.py
+++ b/src/preset_cli/cli/main.py
@@ -6,13 +6,15 @@ import getpass
 import logging
 import sys
 import webbrowser
-from typing import List, Optional, cast
+from collections import defaultdict
+from typing import Any, DefaultDict, Dict, List, Optional, Set, cast
 
 import click
 import yaml
 from yarl import URL
 
 from preset_cli.api.clients.preset import PresetClient
+from preset_cli.api.clients.superset import SupersetClient
 from preset_cli.auth.jwt import JWTAuth
 from preset_cli.auth.lib import (
     get_access_token,
@@ -70,6 +72,16 @@ def parse_selection(selection: str, count: int) -> List[int]:
             numbers.append(int(part))
 
     return numbers
+
+
+workspace_role_identifiers = {
+    "workspace admin": "Admin",
+    "primary contributor": "PresetAlpha",
+    "limited contributor": "PresetGamma",
+    "viewer": "PresetReportsOnly",
+    "dashboard viewer": "PresetDashboardsOnly",
+    "no access": "PresetNoAccess",
+}
 
 
 @click.group()
@@ -311,7 +323,159 @@ def import_users(ctx: click.core.Context, teams: List[str], path: str) -> None:
         client.import_users(teams, users)
 
 
+@click.command()
+@click.option("--teams", callback=split_comma)
+@click.argument(
+    "path",
+    type=click.Path(resolve_path=True),
+    default="user_roles.yaml",
+)
+@click.pass_context
+def sync_roles(ctx: click.core.Context, teams: List[str], path: str) -> None:
+    """
+    Sync user roles (team, workspace, and data access).
+    """
+    client = PresetClient(ctx.obj["MANAGER_URL"], ctx.obj["AUTH"])
+
+    if not teams:
+        teams = get_teams(client)
+
+    with open(path, encoding="utf-8") as input_:
+        user_roles = yaml.load(input_, Loader=yaml.SafeLoader)
+
+    for team_name in teams:
+        workspaces = client.get_workspaces(team_name)
+        sync_all_user_roles_to_team(client, team_name, user_roles, workspaces)
+
+
+def sync_all_user_roles_to_team(  # pylint: disable=too-many-locals
+    client: PresetClient,
+    team_name: str,
+    user_roles: List[Dict[str, Any]],
+    workspaces: List[Dict[str, Any]],
+) -> None:
+    """
+    Sync all user roles to a given team.
+    """
+    workspace_names = {
+        workspace["title"]: workspace["name"] for workspace in workspaces
+    }
+    workspace_hostnames = {
+        workspace["name"]: workspace["hostname"] for workspace in workspaces
+    }
+
+    users = client.get_team_members(team_name)
+    user_ids = {user["user"]["email"]: user["user"]["id"] for user in users}
+
+    for user in user_roles:
+        user["id"] = user_ids[user["email"]]
+        sync_user_roles_to_team(client, team_name, user, workspaces)
+
+    # collect DAR roles so we can do a single request per workspace
+    data_access_roles: DefaultDict[str, DefaultDict[str, Set]] = defaultdict(
+        lambda: defaultdict(set),
+    )
+    for user in user_roles:
+        for workspace_name, workspace_roles in user["workspaces"].items():
+            # allow either a workspace name or title
+            if workspace_name in workspace_names:
+                workspace_name = workspace_names[workspace_name]
+            workspace_hostname = workspace_hostnames[workspace_name]
+
+            for data_access_role in workspace_roles.get("data_access_roles", []):
+                data_access_roles[workspace_hostname][data_access_role].add(
+                    user["email"],
+                )
+
+    for workspace_hostname, workspace_data_access_roles in data_access_roles.items():
+        superset_client = SupersetClient(f"https://{workspace_hostname}/", client.auth)
+
+        user_id_map = {
+            user["email"]: user["id"] for user in superset_client.export_users()
+        }
+        for data_access_role, user_emails in workspace_data_access_roles.items():
+            role_id = superset_client.get_role_id(data_access_role)
+            workspace_user_ids = [user_id_map[email] for email in user_emails]
+            superset_client.update_role(role_id, user=workspace_user_ids)
+
+
+def sync_user_roles_to_team(
+    client: PresetClient,
+    team_name: str,
+    user: Dict[str, Any],
+    workspaces: List[Dict[str, Any]],
+) -> None:
+    """
+    Sync roles from a single user to a given team.
+    """
+    workspace_names = {
+        workspace["title"]: workspace["name"] for workspace in workspaces
+    }
+    workspace_ids = {workspace["name"]: workspace["id"] for workspace in workspaces}
+
+    team_role = user["team_role"].lower()
+    user_email = user["email"]
+    user_id = user["id"]
+
+    if team_role == "user":
+        role_id = 2
+    elif team_role == "admin":
+        role_id = 1
+    else:
+        raise Exception(f"Invalid role {team_role.title()} for user {user_email}")
+    _logger.info(
+        "Setting team role of user %s to %s (%s) in team %s",
+        user_email,
+        role_id,
+        team_role.title(),
+        team_name,
+    )
+    client.change_team_role(team_name, user_id, role_id)
+
+    for workspace_name, workspace_roles in user["workspaces"].items():
+        # allow either a workspace name or title
+        if workspace_name in workspace_names:
+            workspace_name = workspace_names[workspace_name]
+        workspace_id = workspace_ids[workspace_name]
+
+        sync_user_role_to_workspace(
+            client,
+            team_name,
+            user,
+            workspace_id,
+            workspace_roles,
+        )
+
+
+def sync_user_role_to_workspace(
+    client: PresetClient,
+    team_name: str,
+    user: Dict[str, Any],
+    workspace_id: int,
+    workspace_roles: Dict[str, Any],
+) -> None:
+    """
+    Sync user role to a given workspace.
+    """
+    workspace_role = workspace_roles["workspace_role"].lower()
+    role_identifier = workspace_role_identifiers[workspace_role]
+
+    _logger.info(
+        "Setting workspace role of user %s to %s (%s)",
+        user["email"],
+        role_identifier,
+        workspace_role.title(),
+    )
+    client.change_workspace_role(
+        team_name,
+        workspace_id,
+        user["id"],
+        role_identifier,
+    )
+
+
 preset_cli.add_command(auth)
 preset_cli.add_command(invite_users)
 preset_cli.add_command(import_users)
+preset_cli.add_command(sync_roles)
 preset_cli.add_command(superset)

--- a/tests/api/clients/preset_test.py
+++ b/tests/api/clients/preset_test.py
@@ -227,3 +227,100 @@ def test_preset_client_import_users(requests_mock: Mocker) -> None:
         "userName": "adoe@example.com",
         "name": {"formatted": "Alice Doe", "familyName": "Doe", "givenName": "Alice"},
     }
+
+
+def test_get_team_members(requests_mock: Mocker) -> None:
+    """
+    Test the ``get_team_members`` method.
+    """
+    requests_mock.get(
+        "https://ws.preset.io/api/v1/teams/botafogo/memberships",
+        json={
+            "payload": [
+                {
+                    "user": {
+                        "username": "adoe",
+                        "first_name": "Alice",
+                        "last_name": "Doe",
+                        "email": "adoe@example.com",
+                    },
+                },
+                {
+                    "user": {
+                        "username": "bdoe",
+                        "first_name": "Bob",
+                        "last_name": "Doe",
+                        "email": "bdoe@example.com",
+                    },
+                },
+                {
+                    "user": {
+                        "username": "cdoe",
+                        "first_name": "Clarisse",
+                        "last_name": "Doe",
+                        "email": "cdoe@example.com",
+                    },
+                },
+            ],
+        },
+    )
+
+    auth = Auth()
+    client = PresetClient("https://ws.preset.io/", auth)
+    assert client.get_team_members("botafogo") == [
+        {
+            "user": {
+                "username": "adoe",
+                "first_name": "Alice",
+                "last_name": "Doe",
+                "email": "adoe@example.com",
+            },
+        },
+        {
+            "user": {
+                "username": "bdoe",
+                "first_name": "Bob",
+                "last_name": "Doe",
+                "email": "bdoe@example.com",
+            },
+        },
+        {
+            "user": {
+                "username": "cdoe",
+                "first_name": "Clarisse",
+                "last_name": "Doe",
+                "email": "cdoe@example.com",
+            },
+        },
+    ]
+
+
+def test_change_team_role(requests_mock: Mocker) -> None:
+    """
+    Test the ``change_team_role`` method.
+    """
+    requests_mock.patch("https://ws.preset.io/api/v1/teams/botafogo/memberships/1")
+
+    auth = Auth()
+    client = PresetClient("https://ws.preset.io/", auth)
+    client.change_team_role("botafogo", 1, 2)
+
+    assert requests_mock.last_request.json() == {"team_role_id": 2}
+
+
+def test_change_workspace_role(requests_mock: Mocker) -> None:
+    """
+    Test the ``change_workspace_role`` method.
+    """
+    requests_mock.put(
+        "https://ws.preset.io/api/v1/teams/botafogo/workspaces/1/membership",
+    )
+
+    auth = Auth()
+    client = PresetClient("https://ws.preset.io/", auth)
+    client.change_workspace_role("botafogo", 1, 2, "PresetAlpha")
+
+    assert requests_mock.last_request.json() == {
+        "role_identifier": "PresetAlpha",
+        "user_id": 2,
+    }

--- a/tests/cli/main_test.py
+++ b/tests/cli/main_test.py
@@ -13,7 +13,14 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest_mock import MockerFixture
 from yarl import URL
 
-from preset_cli.cli.main import get_status_icon, parse_selection, preset_cli
+from preset_cli.cli.main import (
+    get_status_icon,
+    parse_selection,
+    preset_cli,
+    sync_all_user_roles_to_team,
+    sync_user_role_to_workspace,
+    sync_user_roles_to_team,
+)
 from preset_cli.lib import split_comma
 
 
@@ -572,4 +579,321 @@ def test_import_users_choose_teams(mocker: MockerFixture, fs: FakeFilesystem) ->
             {"first_name": "Alice", "last_name": "Doe", "email": "adoe@example.com"},
             {"first_name": "Bob", "last_name": "Doe", "email": "bdoe@example.com"},
         ],
+    )
+
+
+def test_sync_roles(mocker: MockerFixture, fs: FakeFilesystem) -> None:
+    """
+    Test the ``sync_roles`` command.
+    """
+    PresetClient = mocker.patch("preset_cli.cli.main.PresetClient")
+    client = PresetClient()
+    client.get_workspaces.return_value = [
+        {"workspace_status": "READY", "title": "My Workspace", "hostname": "ws1"},
+        {"workspace_status": "READY", "title": "My Other Workspace", "hostname": "ws2"},
+    ]
+    sync_all_user_roles_to_team = mocker.patch(
+        "preset_cli.cli.main.sync_all_user_roles_to_team",
+    )
+
+    user_roles = [
+        {
+            "email": "adoe@example.com",
+            "team_role": "Admin",
+            "workspaces": {
+                "My Workspace": {
+                    "workspace_role": "Limited Contributor",
+                    "data_access_roles": ["Database access on A Postgres database"],
+                },
+            },
+        },
+    ]
+    fs.create_file("user_roles.yaml", contents=yaml.dump(user_roles))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        preset_cli,
+        ["--jwt-token=XXX", "sync-roles", "--teams=team1"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    client.get_workspaces.assert_called_with("team1")
+    sync_all_user_roles_to_team.assert_called_with(
+        client,
+        "team1",
+        user_roles,
+        [
+            {"workspace_status": "READY", "title": "My Workspace", "hostname": "ws1"},
+            {
+                "workspace_status": "READY",
+                "title": "My Other Workspace",
+                "hostname": "ws2",
+            },
+        ],
+    )
+
+    mocker.patch("preset_cli.cli.main.get_teams", return_value=["team1"])
+    result = runner.invoke(
+        preset_cli,
+        ["--jwt-token=XXX", "sync-roles"],
+        catch_exceptions=False,
+    )
+    client.get_workspaces.assert_called_with("team1")
+
+
+def test_sync_all_user_roles_to_team(mocker: MockerFixture) -> None:
+    """
+    Test the ``sync_all_user_roles_to_team`` helper.
+    """
+    sync_user_roles_to_team = mocker.patch(
+        "preset_cli.cli.main.sync_user_roles_to_team",
+    )
+    client = mocker.MagicMock()
+    client.get_team_members.return_value = [
+        {"user": {"email": "adoe@example.com", "id": 1001}},
+        {"user": {"email": "bdoe@example.com", "id": 1002}},
+    ]
+    SupersetClient = mocker.patch("preset_cli.cli.main.SupersetClient")
+    superset_client = SupersetClient()
+    superset_client.export_users.return_value = [
+        {"email": "adoe@example.com", "id": 1},
+        {"email": "bdoe@example.com", "id": 2},
+    ]
+    superset_client.get_role_id.return_value = 42
+    workspaces = [
+        {"name": "ws1", "title": "My Workspace", "hostname": "ws1.example.org"},
+        {"name": "ws2", "title": "My Other Workspace", "hostname": "ws2.example.org"},
+    ]
+    user_roles = [
+        {
+            "email": "adoe@example.com",
+            "team_role": "Admin",
+            "workspaces": {
+                "ws1": {
+                    "workspace_role": "Limited Contributor",
+                    "data_access_roles": ["Database access on A Postgres database"],
+                },
+            },
+        },
+    ]
+
+    sync_all_user_roles_to_team(client, "team1", user_roles, workspaces)
+
+    sync_user_roles_to_team.assert_called_with(
+        client,
+        "team1",
+        {
+            "id": 1001,
+            "email": "adoe@example.com",
+            "team_role": "Admin",
+            "workspaces": {
+                "ws1": {
+                    "workspace_role": "Limited Contributor",
+                    "data_access_roles": ["Database access on A Postgres database"],
+                },
+            },
+        },
+        workspaces,
+    )
+    SupersetClient.assert_called_with("https://ws1.example.org/", client.auth)
+    superset_client.update_role.assert_called_with(42, user=[1])
+
+
+def test_sync_all_user_roles_to_team_workspace_title(mocker: MockerFixture) -> None:
+    """
+    Test the ``sync_all_user_roles_to_team`` helper.
+
+    Here the config uses the workspace title instead of the name.
+    """
+    sync_user_roles_to_team = mocker.patch(
+        "preset_cli.cli.main.sync_user_roles_to_team",
+    )
+    client = mocker.MagicMock()
+    client.get_team_members.return_value = [
+        {"user": {"email": "adoe@example.com", "id": 1001}},
+        {"user": {"email": "bdoe@example.com", "id": 1002}},
+    ]
+    SupersetClient = mocker.patch("preset_cli.cli.main.SupersetClient")
+    superset_client = SupersetClient()
+    superset_client.export_users.return_value = [
+        {"email": "adoe@example.com", "id": 1},
+        {"email": "bdoe@example.com", "id": 2},
+    ]
+    superset_client.get_role_id.return_value = 42
+    workspaces = [
+        {"name": "ws1", "title": "My Workspace", "hostname": "ws1.example.org"},
+        {"name": "ws2", "title": "My Other Workspace", "hostname": "ws2.example.org"},
+    ]
+    user_roles = [
+        {
+            "email": "adoe@example.com",
+            "team_role": "Admin",
+            "workspaces": {
+                "My Workspace": {
+                    "workspace_role": "Limited Contributor",
+                    "data_access_roles": ["Database access on A Postgres database"],
+                },
+            },
+        },
+    ]
+
+    sync_all_user_roles_to_team(client, "team1", user_roles, workspaces)
+
+    sync_user_roles_to_team.assert_called_with(
+        client,
+        "team1",
+        {
+            "id": 1001,
+            "email": "adoe@example.com",
+            "team_role": "Admin",
+            "workspaces": {
+                "My Workspace": {
+                    "workspace_role": "Limited Contributor",
+                    "data_access_roles": ["Database access on A Postgres database"],
+                },
+            },
+        },
+        workspaces,
+    )
+    SupersetClient.assert_called_with("https://ws1.example.org/", client.auth)
+    superset_client.update_role.assert_called_with(42, user=[1])
+
+
+def test_sync_user_roles_to_team(mocker: MockerFixture) -> None:
+    """
+    Test the ``sync_user_roles_to_team`` helper.
+    """
+    sync_user_role_to_workspace = mocker.patch(
+        "preset_cli.cli.main.sync_user_role_to_workspace",
+    )
+    client = mocker.MagicMock()
+    user = {
+        "id": 1001,
+        "email": "adoe@example.com",
+        "team_role": "Admin",
+        "workspaces": {
+            "My Workspace": {
+                "workspace_role": "Limited Contributor",
+                "data_access_roles": ["Database access on A Postgres database"],
+            },
+        },
+    }
+    workspaces = [
+        {
+            "id": 1,
+            "name": "ws1",
+            "title": "My Workspace",
+            "hostname": "ws1.example.org",
+        },
+        {
+            "id": 2,
+            "name": "ws2",
+            "title": "My Other Workspace",
+            "hostname": "ws2.example.org",
+        },
+    ]
+
+    sync_user_roles_to_team(client, "team1", user, workspaces)
+
+    client.change_team_role.assert_called_with("team1", 1001, 1)
+    sync_user_role_to_workspace.assert_called_with(
+        client,
+        "team1",
+        user,
+        1,
+        {
+            "data_access_roles": ["Database access on A Postgres database"],
+            "workspace_role": "Limited Contributor",
+        },
+    )
+
+    user = {
+        "id": 1001,
+        "email": "adoe@example.com",
+        "team_role": "User",
+        "workspaces": {
+            "My Workspace": {
+                "workspace_role": "Limited Contributor",
+                "data_access_roles": ["Database access on A Postgres database"],
+            },
+        },
+    }
+    sync_user_roles_to_team(client, "team1", user, workspaces)
+    client.change_team_role.assert_called_with("team1", 1001, 2)
+
+    user = {
+        "id": 1001,
+        "email": "adoe@example.com",
+        "team_role": "Super Mega Admin",
+        "workspaces": {
+            "My Workspace": {
+                "workspace_role": "Limited Contributor",
+                "data_access_roles": ["Database access on A Postgres database"],
+            },
+        },
+    }
+    with pytest.raises(Exception) as excinfo:
+        sync_user_roles_to_team(client, "team1", user, workspaces)
+    assert (
+        str(excinfo.value) == "Invalid role Super Mega Admin for user adoe@example.com"
+    )
+
+    user = {
+        "id": 1001,
+        "email": "adoe@example.com",
+        "team_role": "User",
+        "workspaces": {
+            "ws1": {
+                "workspace_role": "Limited Contributor",
+                "data_access_roles": ["Database access on A Postgres database"],
+            },
+        },
+    }
+    sync_user_roles_to_team(client, "team1", user, workspaces)
+    sync_user_role_to_workspace.assert_called_with(
+        client,
+        "team1",
+        user,
+        1,
+        {
+            "data_access_roles": ["Database access on A Postgres database"],
+            "workspace_role": "Limited Contributor",
+        },
+    )
+
+
+def test_sync_user_role_to_workspace(mocker: MockerFixture) -> None:
+    """
+    Test the ``sync_user_role_to_workspace`` helper.
+    """
+    client = mocker.MagicMock()
+    user = {
+        "id": 1001,
+        "email": "adoe@example.com",
+        "team_role": "User",
+        "workspaces": {
+            "ws1": {
+                "workspace_role": "Limited Contributor",
+                "data_access_roles": ["Database access on A Postgres database"],
+            },
+        },
+    }
+
+    sync_user_role_to_workspace(
+        client,
+        "team1",
+        user,
+        1,
+        {
+            "data_access_roles": ["Database access on A Postgres database"],
+            "workspace_role": "Limited Contributor",
+        },
+    )
+
+    client.change_workspace_role.assert_called_with(
+        "team1",
+        1,
+        1001,
+        "PresetGamma",
     )


### PR DESCRIPTION
Given a YAML file `user_roles.yaml`:

```yaml
- email: ralmeida+10@gmail.com
  team_role: admin 
  workspaces:
    Strategic Pod:
      workspace_role: Limited Contributor
      data_access_roles:
      - test Public
```

We can sync team/workspace/DAR roles to Preset with:

```bash
$ preset-cli sync-roles
```
