### PR TITLE
fix: add children to models from dbt core

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -106,7 +106,8 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-locals
     for config in configs["nodes"].values():
         if config["resource_type"] == "model":
             # conform to the same schema that dbt Cloud uses for models
-            config["uniqueId"] = config["unique_id"]
+            unique_id = config["uniqueId"] = config["unique_id"]
+            config["children"] = configs["child_map"][unique_id]
             models.append(model_schema.load(config, unknown=EXCLUDE))
     models = apply_select(models, select, exclude)
 

--- a/tests/cli/superset/sync/dbt/manifest.json
+++ b/tests/cli/superset/sync/dbt/manifest.json
@@ -303,5 +303,17 @@
       "column_name": "customer_id",
       "file_key_name": "models.stg_customers"
     }
+  },
+  "child_map": {
+    "model.superset_examples.messages_channels": [
+      "metric.superset_examples.cnt"
+    ],
+    "source.superset_examples.public.messages": [
+      "model.superset_examples.messages_channels"
+    ],
+    "source.superset_examples.public.channels": [
+      "model.superset_examples.messages_channels"
+    ],
+    "metric.superset_examples.cnt": []
   }
 }


### PR DESCRIPTION
The model schema in dbt Core doesn't have a `children` attribute, unlike the model schema from dbt Cloud. This PR adds the attribute so we can use the graph selection.

Closes #69.