### PR TITLE
fix: ignore non-asset dirs in native sync

### DIFF
--- a/tests/cli/superset/sync/native/command_test.py
+++ b/tests/cli/superset/sync/native/command_test.py
@@ -165,6 +165,10 @@ def test_native(mocker: MockerFixture, fs: FakeFilesystem) -> None:
         root / "README.txt",
         contents="Hello, world",
     )
+    fs.create_file(
+        root / "tmp/file.yaml",
+        contents=yaml.dump([1, 2, 3]),
+    )
 
     SupersetClient = mocker.patch(
         "preset_cli.cli.superset.sync.native.command.SupersetClient",


### PR DESCRIPTION
When doing a native sync, ignore YAML files inside directories that are not for assets.