### PR TITLE
feat: support DUO MFA passcode in Snowflake

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -165,6 +165,22 @@ def build_snowflake_sqlalchemy_params(target: Dict[str, Any]) -> Dict[str, Any]:
         ),
     }
 
+    authenticator = target.get("authenticator")
+    if authenticator:
+        if authenticator == "externalbrowser":
+            raise NotImplementedError("SSO not supported")
+        if authenticator.startswith("http"):
+            raise NotImplementedError("SSO not supported")
+        parameters["extra"] = json.dumps(
+            {
+                "engine_params": {
+                    "connect_args": {
+                        "passcode": authenticator,
+                    },
+                },
+            },
+        )
+
     if "private_key_path" in target:
         with open(target["private_key_path"], encoding="utf-8") as input_:
             pk_body = input_.read()

--- a/tests/cli/superset/sync/dbt/lib_test.py
+++ b/tests/cli/superset/sync/dbt/lib_test.py
@@ -185,6 +185,31 @@ def test_build_snowflake_sqlalchemy_params_pk(fs: FakeFilesystem) -> None:
     }
 
 
+def test_build_snowflake_sqlalchemy_params_mfa() -> None:
+    """
+    Test ``build_snowflake_sqlalchemy_params`` for Snowflake with MFA.
+    """
+    config = {
+        "type": "snowflake",
+        "account": "abc123.eu-west-1.aws",
+        "user": "jdoe",
+        "password": "secret",
+        "authenticator": "DUO code",
+        "role": "admin",
+        "database": "default",
+        "warehouse": "dunder-mifflin",
+    }
+    assert build_sqlalchemy_params(config) == {
+        "sqlalchemy_uri": (
+            "snowflake://jdoe:secret@abc123.eu-west-1.aws/default?"
+            "role=admin&warehouse=dunder-mifflin"
+        ),
+        "extra": json.dumps(
+            {"engine_params": {"connect_args": {"passcode": "DUO code"}}},
+        ),
+    }
+
+
 def test_build_sqlalchemy_params_unsupported() -> None:
     """
     Test ``build_sqlalchemy_params`` for databases currently unsupported.


### PR DESCRIPTION
Allow passing a DUO generated passcode to the [dbt config](https://docs.getdbt.com/reference/warehouse-setups/snowflake-setup#user--password--duo-mfa-authentication):

```yaml
my-snowflake-db:
  target: dev
  outputs:
    dev:
      type: snowflake
      account: [account id]

      # User/password auth
      user: [username]
      password: [password]
      authenticator: username_password_mfa  # HERE

      ...
"""