### PR TITLE
feat (dbt): pass `dbt_project.yml`

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/databases.py
+++ b/src/preset_cli/cli/superset/sync/dbt/databases.py
@@ -19,6 +19,7 @@ def sync_database(  # pylint: disable=too-many-locals, too-many-arguments
     client: SupersetClient,
     profiles_path: Path,
     project_name: str,
+    profile_name: str,
     target_name: Optional[str],
     import_db: bool,
     disallow_edits: bool,  # pylint: disable=unused-argument
@@ -29,7 +30,7 @@ def sync_database(  # pylint: disable=too-many-locals, too-many-arguments
     """
     base_url = URL(external_url_prefix) if external_url_prefix else None
 
-    profiles = load_profiles(profiles_path, project_name, target_name)
+    profiles = load_profiles(profiles_path, project_name, profile_name, target_name)
     project = profiles[project_name]
     outputs = project["outputs"]
     if target_name is None:

--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -232,7 +232,10 @@ class Target(TypedDict):
 
 
 def load_profiles(
-    path: Path, project_name: str, target_name: Optional[str],
+    path: Path,
+    project_name: str,
+    profile_name: str,
+    target_name: Optional[str],
 ) -> Dict[str, Any]:
     """
     Load the file and apply Jinja2 templating.
@@ -240,9 +243,9 @@ def load_profiles(
     with open(path, encoding="utf-8") as input_:
         profiles = yaml.load(input_, Loader=yaml.SafeLoader)
 
-    if project_name not in profiles:
-        raise Exception(f"Project {project_name} not found in {path}")
-    project = profiles[project_name]
+    if profile_name not in profiles:
+        raise Exception(f"Project {profile_name} not found in {path}")
+    project = profiles[profile_name]
     outputs = project["outputs"]
     if target_name is None:
         target_name = project["target"]
@@ -259,6 +262,7 @@ def load_profiles(
     context = {
         "env_var": env_var,
         "project_name": project_name,
+        "profile_name": profile_name,
         "target": target,
     }
 

--- a/tests/cli/superset/sync/dbt/databases_test.py
+++ b/tests/cli/superset/sync/dbt/databases_test.py
@@ -33,6 +33,7 @@ def test_sync_database_new(mocker: MockerFixture, fs: FakeFilesystem) -> None:
         client=client,
         profiles_path=Path("/path/to/.dbt/profiles.yml"),
         project_name="my_project",
+        profile_name="my_project",
         target_name="dev",
         import_db=True,
         disallow_edits=False,
@@ -48,7 +49,8 @@ def test_sync_database_new(mocker: MockerFixture, fs: FakeFilesystem) -> None:
 
 
 def test_sync_database_new_default_target(
-    mocker: MockerFixture, fs: FakeFilesystem
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
 ) -> None:
     """
     Test ``sync_database`` when we want to import a new DB using the default target.
@@ -68,6 +70,7 @@ def test_sync_database_new_default_target(
         client=client,
         profiles_path=Path("/path/to/.dbt/profiles.yml"),
         project_name="my_project",
+        profile_name="my_project",
         target_name=None,
         import_db=True,
         disallow_edits=False,
@@ -121,6 +124,7 @@ def test_sync_database_new_custom_sqlalchemy_uri(
         client=client,
         profiles_path=Path("/path/to/.dbt/profiles.yml"),
         project_name="my_project",
+        profile_name="my_project",
         target_name="dev",
         import_db=True,
         disallow_edits=False,
@@ -177,6 +181,7 @@ def test_sync_database_env_var(
         client=client,
         profiles_path=Path("/path/to/.dbt/profiles.yml"),
         project_name="my_project",
+        profile_name="my_project",
         target_name="dev",
         import_db=True,
         disallow_edits=False,
@@ -206,7 +211,8 @@ def test_sync_database_no_project(mocker: MockerFixture, fs: FakeFilesystem) -> 
         sync_database(
             client=client,
             profiles_path=Path("/path/to/.dbt/profiles.yml"),
-            project_name="my_other_project",
+            project_name="my_project",
+            profile_name="my_other_project",
             target_name="dev",
             import_db=True,
             disallow_edits=False,
@@ -234,6 +240,7 @@ def test_sync_database_no_target(mocker: MockerFixture, fs: FakeFilesystem) -> N
             client=client,
             profiles_path=Path("/path/to/.dbt/profiles.yml"),
             project_name="my_project",
+            profile_name="my_project",
             target_name="prod",
             import_db=True,
             disallow_edits=False,
@@ -273,6 +280,7 @@ def test_sync_database_multiple_databases(
             client=client,
             profiles_path=Path("/path/to/.dbt/profiles.yml"),
             project_name="my_project",
+            profile_name="my_project",
             target_name="dev",
             import_db=True,
             disallow_edits=False,
@@ -303,6 +311,7 @@ def test_sync_database_external_url_prefix(
         client=client,
         profiles_path=Path("/path/to/.dbt/profiles.yml"),
         project_name="my_project",
+        profile_name="my_project",
         target_name="dev",
         import_db=True,
         disallow_edits=True,
@@ -339,6 +348,7 @@ def test_sync_database_existing(mocker: MockerFixture, fs: FakeFilesystem) -> No
         client=client,
         profiles_path=Path("/path/to/.dbt/profiles.yml"),
         project_name="my_project",
+        profile_name="my_project",
         target_name="dev",
         import_db=True,
         disallow_edits=False,
@@ -374,6 +384,7 @@ def test_sync_database_new_no_import(mocker: MockerFixture, fs: FakeFilesystem) 
             client=client,
             profiles_path=Path("/path/to/.dbt/profiles.yml"),
             project_name="my_project",
+            profile_name="my_project",
             target_name="dev",
             import_db=False,
             disallow_edits=False,

--- a/tests/cli/superset/sync/dbt/lib_test.py
+++ b/tests/cli/superset/sync/dbt/lib_test.py
@@ -283,7 +283,7 @@ jaffle_shop:
     """,
     )
 
-    assert load_profiles(path, "jaffle_shop", "dev") == {
+    assert load_profiles(path, "jaffle_shop", "jaffle_shop", "dev") == {
         "jaffle_shop": {
             "outputs": {
                 "dev": {
@@ -306,7 +306,8 @@ jaffle_shop:
 
 
 def test_load_profiles_default_target(
-    monkeypatch: pytest.MonkeyPatch, fs: FakeFilesystem
+    monkeypatch: pytest.MonkeyPatch,
+    fs: FakeFilesystem,
 ) -> None:
     """
     Test ``load_profiles`` when no target is specified.
@@ -340,7 +341,7 @@ jaffle_shop:
     """,
     )
 
-    assert load_profiles(path, "jaffle_shop", None) == {
+    assert load_profiles(path, "jaffle_shop", "jaffle_shop", None) == {
         "jaffle_shop": {
             "outputs": {
                 "dev": {


### PR DESCRIPTION
Allow passing `dbt_project.yml` instead of `manifest.json`, since it has more information and we can infer the manifest location from it.