### PR TITLE
fix: allow `None` as a column type

### DIFF
--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -531,6 +531,9 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
             column["groupby"] = True
             if column["is_dttm"]:
                 column["type_generic"] = 2
+            elif column["type"] is None:
+                column["type"] = "UNKNOWN"
+                column["type_generic"] = 1
             elif column["type"].lower() == "string":
                 column["type_generic"] = 1
             else:

--- a/tests/api/clients/superset_test.py
+++ b/tests/api/clients/superset_test.py
@@ -2669,19 +2669,27 @@ def test_create_virtual_dataset(requests_mock: Mocker) -> None:
             "query_id": 137,
             "status": "success",
             "data": [
-                {"ID": 20, "FIRST_NAME": "Anna", "LAST_NAME": "A.", "ds": "2022-01-01"},
+                {
+                    "ID": 20,
+                    "FIRST_NAME": "Anna",
+                    "LAST_NAME": "A.",
+                    "ds": "2022-01-01",
+                    "complex": r"\x00",
+                },
             ],
             "columns": [
                 {"name": "ID", "type": "INTEGER", "is_dttm": False},
                 {"name": "FIRST_NAME", "type": "STRING", "is_dttm": False},
                 {"name": "LAST_NAME", "type": "STRING", "is_dttm": False},
                 {"name": "ds", "type": "DATETIME", "is_dttm": True},
+                {"name": "complex", "type": None, "is_dttm": False},
             ],
             "selected_columns": [
                 {"name": "ID", "type": "INTEGER", "is_dttm": False},
                 {"name": "FIRST_NAME", "type": "STRING", "is_dttm": False},
                 {"name": "LAST_NAME", "type": "STRING", "is_dttm": False},
                 {"name": "ds", "type": "DATETIME", "is_dttm": True},
+                {"name": "complex", "type": None, "is_dttm": False},
             ],
             "expanded_columns": [],
             "query": {
@@ -2719,6 +2727,7 @@ def test_create_virtual_dataset(requests_mock: Mocker) -> None:
                         {"name": "FIRST_NAME", "type": "STRING", "is_dttm": False},
                         {"name": "LAST_NAME", "type": "STRING", "is_dttm": False},
                         {"name": "ds", "type": "DATETIME", "is_dttm": True},
+                        {"name": "complex", "type": None, "is_dttm": False},
                     ],
                 },
             },
@@ -2778,6 +2787,14 @@ def test_create_virtual_dataset(requests_mock: Mocker) -> None:
                 "column_name": "ds",
                 "groupby": True,
                 "type_generic": 2,
+            },
+            {
+                "name": "complex",
+                "type": "UNKNOWN",
+                "is_dttm": False,
+                "column_name": "complex",
+                "groupby": True,
+                "type_generic": 1,
             },
         ],
     }


### PR DESCRIPTION
Tentative fix for https://github.com/preset-io/backend-sdk/issues/113.

When creating a virtual dataset from a dbt model in Snowflake we're getting the following error:

```
[[09:32:48]] ERROR: preset_cli.cli.superset.sync.dbt.datasets: Unable to create dataset                                                                                                           datasets.py:99
                    Traceback (most recent call last):                                                                                                                                                                              
                      File "/usr/local/lib/python3.9/site-packages/preset_cli/cli/superset/sync/dbt/datasets.py", line 97, in sync_datasets                                                                                         
                        dataset = create_dataset(client, database, model)                                                                                                                                                           
                      File "/usr/local/lib/python3.9/site-packages/preset_cli/cli/superset/sync/dbt/datasets.py", line 63, in create_dataset                                                                                        
                        return client.create_dataset(**kwargs)                                                                                                                                                                      
                      File "/usr/local/lib/python3.9/site-packages/preset_cli/api/clients/superset.py", line 534, in create_dataset                                                                                                 
                        elif column["type"].lower() == "string":                                                                                                                                                                    
                    AttributeError: 'NoneType' object has no attribute 'lower'                                  
```

Which suggests that when running `SELECT * FROM {source}` to infer the column names and types in the model at least one of the columns has the type set to `None` (coming from `inspect.get_columns`, so it's being set by the Snowflake driver).

I fixed it by checking for this case, and setting the column type to the most generic when this happens.