### PR TITLE
fix: don't log password

### DIFF
--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -219,7 +219,7 @@ def verify_db_connectivity(config: Dict[str, Any]) -> None:
         raw_connection = engine.raw_connection()
         engine.dialect.do_ping(raw_connection)
     except Exception as ex:  # pylint: disable=broad-except
-        _logger.warning("Cannot connect to database %s", uri)
+        _logger.warning("Cannot connect to database %s", repr(uri))
         _logger.debug(ex)
 
 

--- a/tests/cli/superset/sync/native/command_test.py
+++ b/tests/cli/superset/sync/native/command_test.py
@@ -562,12 +562,5 @@ def test_verify_db_connectivity_error(mocker: MockerFixture) -> None:
 
     _logger.warning.assert_called_with(
         "Cannot connect to database %s",
-        URL(
-            "postgresql",
-            username="username",
-            password="SECRET",
-            host="localhost",
-            port=5432,
-            database="examples",
-        ),
+        "postgresql://username:***@localhost:5432/examples",
     )


### PR DESCRIPTION
Prevent logging the database password when we can't connect to it.

cc: @cwegener