### PR TITLE
feat (native sync): split imports and more

### DIFF
--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -662,6 +662,8 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
         """
         Import a ZIP bundle.
         """
+        key = "bundle" if resource_name == "assets" else "formData"
+        files = {key: form_data}
         url = self.baseurl / "api/v1" / resource_name / "import/"
 
         self.session.headers.update({"Accept": "application/json"})
@@ -669,7 +671,7 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
         _logger.debug("POST %s\n%s", url, json.dumps(data, indent=4))
         response = self.session.post(
             url,
-            files=dict(formData=form_data),
+            files=files,
             data=data,
         )
         validate_response(response)


### PR DESCRIPTION
This PR introduces a few changes to the `superset sync native` command:

1. The `--asset-type` option was removed, since it was broken. When importing an asset (say, a dataset) all related assets should be included in the bundle (database, in this example), which defeats the purpose of syncing only a few assets.
2. The command now uses the `/api/v1/assets/import` endpoint in Superset, requiring a single request instead of 4 separate requests.
3. A new option `--split` was added. When set the CLI will imports assets one by one (with related assets), starting with databases, then datasets, charts, dashboards.

```bash
$ preset-cli --workspaces=https://816a0e96.us2a.app.preset.io/ superset sync native ~/Projects/headless-bi-blog-post-examples/ --overwrite --split

https://816a0e96.us2a.app.preset.io/
[11:56:24] INFO     [[11:56:24]] INFO: preset_cli.cli.superset.sync.native.command: Importing databases/Google_Sheets.yaml                                                                                                                                                                                                                                                                                                                                                            command.py:220
[11:56:27] INFO     [[11:56:27]] INFO: preset_cli.cli.superset.sync.native.command: Importing datasets/Google_Sheets/country_cnt.yaml                                                                                                                                                                                                                                                                                                                                                 command.py:220
[11:56:29] INFO     [[11:56:29]] INFO: preset_cli.cli.superset.sync.native.command: Importing charts/Count_per_country_79.yaml                                                                                                                                                                                                                                                                                                                                                        command.py:220
[11:56:30] INFO     [[11:56:30]] INFO: preset_cli.cli.superset.sync.native.command: Importing dashboards/Demo_dashboard.yaml       
```

Closes https://github.com/preset-io/backend-sdk/issues/123.