### PR TITLE
feat: infer dbt models from dataset

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203, E266, E501, W503, F403, F401
+ignore = E203, E266, E501, W503, F403, F401, W293
 max-line-length = 79
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/src/preset_cli/api/clients/preset.py
+++ b/src/preset_cli/api/clients/preset.py
@@ -230,4 +230,7 @@ class PresetClient:  # pylint: disable=too-few-public-methods
         self.session.put(url, json=payload)
 
     def get_base_url(self, version: Optional[str] = "v1") -> URL:
+        """
+        Return the base URL for API calls.
+        """
         return self.baseurl / version

--- a/src/preset_cli/cli/main.py
+++ b/src/preset_cli/cli/main.py
@@ -103,7 +103,7 @@ workspace_role_identifiers = {
 @click.option("--loglevel", default="INFO")
 @click.version_option()
 @click.pass_context
-def preset_cli(  # pylint: disable=too-many-branches, too-many-locals, too-many-arguments
+def preset_cli(  # pylint: disable=too-many-branches, too-many-locals, too-many-arguments, too-many-statements
     ctx: click.core.Context,
     baseurl: str,
     api_token: Optional[str],
@@ -153,7 +153,10 @@ def preset_cli(  # pylint: disable=too-many-branches, too-many-locals, too-many-
                 api_token = input("API token: ")
                 api_secret = getpass.getpass("API secret: ")
                 store_credentials(
-                    api_token, api_secret, manager_api_url, credentials_path
+                    api_token,
+                    api_secret,
+                    manager_api_url,
+                    credentials_path,
                 )
 
         api_token = cast(str, api_token)

--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -160,7 +160,7 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-locals
     )
     if exposures:
         exposures = os.path.expanduser(exposures)
-        sync_exposures(client, Path(exposures), datasets)
+        sync_exposures(client, Path(exposures), datasets, models)
 
 
 @click.command()

--- a/tests/cli/main_test.py
+++ b/tests/cli/main_test.py
@@ -274,7 +274,9 @@ def test_cmd_handling_failed_creds(
     )
     assert result.exit_code == 1
     get_access_token.assert_called_with(
-        URL("https://api.app.preset.io/"), "API_TOKEN", "API_SECRET"
+        URL("https://api.app.preset.io/"),
+        "API_TOKEN",
+        "API_SECRET",
     )
 
 

--- a/tests/cli/superset/sync/dbt/command_test.py
+++ b/tests/cli/superset/sync/dbt/command_test.py
@@ -106,7 +106,7 @@ def test_dbt_core(mocker: MockerFixture, fs: FakeFilesystem) -> None:
         False,
         "",
     )
-    sync_exposures.assert_called_with(client, exposures, sync_datasets())
+    sync_exposures.assert_called_with(client, exposures, sync_datasets(), models)
 
 
 def test_dbt_core_dbt_project(mocker: MockerFixture, fs: FakeFilesystem) -> None:
@@ -284,7 +284,7 @@ def test_dbt(mocker: MockerFixture, fs: FakeFilesystem) -> None:
         False,
         "",
     )
-    sync_exposures.assert_called_with(client, exposures, sync_datasets())
+    sync_exposures.assert_called_with(client, exposures, sync_datasets(), models)
 
 
 def test_dbt_core_no_exposures(mocker: MockerFixture, fs: FakeFilesystem) -> None:


### PR DESCRIPTION
The CLI currently offers a command to populate dbt exposures — these are charts and dashboards in Superset that were created based on datasets that map back to dbt models.

Currently, the CLI uses **extra metadata that is added to datasets** when the CLI syncs them from dbt to Superset, eg:

```json
{
  "datasource_type": "table",
  "schema": "public",
  "table_name": "messages_channels",
  ...
  "extra": {
    "resource_type": "model",
    "unique_id": "model.superset_examples.messages_channels",
    "depends_on": "ref('messages_channels')"
  }
}
```

This makes the process of determining which charts and dashboards read from dbt models easy, since we can just check the extra metadata.

A customer has expressed the need for populating exposures from Preset when they have created the dataset manually. Since the datasets don't have the extra metadata, we need to infer the model references from the schema and table name.