### PR TITLE
chore: add 3.11

### DIFF
--- a/.github/workflows/python-package-daily.yml
+++ b/.github/workflows/python-package-daily.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11.0-beta.5']
+        python-version: [3.8, 3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --no-annotate dev-requirements.in
 #
 -e file:.
-aiohttp==3.8.1
+aiohttp==3.8.3
 aiosignal==1.2.0
 appdirs==1.4.4
 async-timeout==4.0.2
@@ -24,7 +24,7 @@ distlib==0.3.5
 filelock==3.8.0
 freezegun==1.2.2
 frozenlist==1.3.1
-greenlet==1.1.2
+greenlet==1.1.3.post0
 identify==2.5.3
 idna==3.3
 iniconfig==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --no-annotate
 #
 -e file:.
-aiohttp==3.8.1
+aiohttp==3.8.3
 aiosignal==1.2.0
 appdirs==1.4.4
 async-timeout==4.0.2
@@ -17,7 +17,7 @@ click==8.1.2
 commonmark==0.9.1
 cython==0.29.28
 frozenlist==1.3.1
-greenlet==1.1.2
+greenlet==1.1.3.post0
 idna==3.3
 jinja2==3.1.1
 markupsafe==2.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,8 @@ install_requires =
     tabulate>=0.8.9
     typing-extensions>=4.0.1
     yarl>=1.7.2
+    greenlet>=1.1.3  # required for Python 3.11
+    aiohttp>=3.8.3
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,10 @@ platforms = any
 classifiers =
     Development Status :: 4 - Beta
     Programming Language :: Python
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     License :: Other/Proprietary License
 
 


### PR DESCRIPTION
Python 3.11 was released today, and our unit tests pass with it. Adding it to unit tests and metadata as a supported version.