### PR TITLE
feat: refresh JWT whenever needed

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -581,7 +581,7 @@ class DBTClient:  # pylint: disable=too-few-public-methods
         self.graphql_client = GraphqlClient(endpoint=GRAPHQL_ENDPOINT)
         self.baseurl = REST_ENDPOINT
 
-        self.session = auth.get_session()
+        self.session = auth.session
         self.session.headers.update(auth.get_headers())
         self.session.headers["User-Agent"] = "Preset CLI"
         self.session.headers["X-Client-Version"] = __version__

--- a/src/preset_cli/api/clients/preset.py
+++ b/src/preset_cli/api/clients/preset.py
@@ -38,7 +38,7 @@ class PresetClient:  # pylint: disable=too-few-public-methods
         self.baseurl = URL(baseurl)
         self.auth = auth
 
-        self.session = auth.get_session()
+        self.session = auth.session
         self.session.headers.update(auth.get_headers())
         self.session.headers["User-Agent"] = "Preset CLI"
         self.session.headers["X-Client-Version"] = __version__

--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -221,7 +221,7 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
         self.baseurl = URL(baseurl)
         self.auth = auth
 
-        self.session = auth.get_session()
+        self.session = auth.session
         self.session.headers.update(auth.get_headers())
         self.session.headers["Referer"] = str(self.baseurl)
         self.session.headers["User-Agent"] = f"Apache Superset Client ({__version__})"

--- a/src/preset_cli/auth/jwt.py
+++ b/src/preset_cli/auth/jwt.py
@@ -8,7 +8,7 @@ from preset_cli.auth.lib import get_access_token, get_credentials_path
 from preset_cli.auth.token import TokenAuth
 
 
-class JWTAuth(TokenAuth):  # pylint: disable=too-few-public-methods
+class JWTAuth(TokenAuth):  # pylint: disable=too-few-public-methods, abstract-method
     """
     Auth via JWT.
     """

--- a/src/preset_cli/auth/main.py
+++ b/src/preset_cli/auth/main.py
@@ -2,9 +2,9 @@
 Mechanisms for authentication and authorization.
 """
 
-from typing import Dict
+from typing import Any, Dict
 
-import requests
+from requests import Response, Session
 
 
 class Auth:  # pylint: disable=too-few-public-methods
@@ -13,17 +13,34 @@ class Auth:  # pylint: disable=too-few-public-methods
     """
 
     def __init__(self):
-        self.session = requests.Session()
-        self.headers = {}
-
-    def get_session(self) -> requests.Session:
-        """
-        Return a session.
-        """
-        return self.session
+        self.session = Session()
+        self.session.hooks["response"].append(self.reauth)
 
     def get_headers(self) -> Dict[str, str]:  # pylint: disable=no-self-use
         """
         Return headers for auth.
         """
-        return self.headers
+        return {}
+
+    def auth(self) -> None:
+        """
+        Perform authentication, fetching JWT tokens, CSRF tokens, cookies, etc.
+        """
+        raise NotImplementedError("Must be implemented for reauthorizing")
+
+    # pylint: disable=invalid-name, unused-argument
+    def reauth(self, r: Response, *args: Any, **kwargs: Any) -> Response:
+        """
+        Catch 401 and re-auth.
+        """
+        if r.status_code != 401:
+            return r
+
+        try:
+            self.auth()
+        except NotImplementedError:
+            return r
+
+        self.session.headers.update(self.get_headers())
+        r.request.headers.update(self.get_headers())
+        return self.session.send(r.request, verify=False)

--- a/src/preset_cli/auth/password.py
+++ b/src/preset_cli/auth/password.py
@@ -2,7 +2,7 @@
 Mechanisms for authentication and authorization.
 """
 
-from typing import Optional
+from typing import Dict, Optional
 
 from bs4 import BeautifulSoup
 from yarl import URL
@@ -17,27 +17,30 @@ class UsernamePasswordAuth(Auth):  # pylint: disable=too-few-public-methods
 
     def __init__(self, baseurl: URL, username: str, password: Optional[str] = None):
         super().__init__()
-        self._do_login(baseurl, username, password)
 
-    def _do_login(
-        self,
-        baseurl: URL,
-        username: str,
-        password: Optional[str] = None,
-    ) -> None:
+        self.csrf_token: Optional[str] = None
+        self.baseurl = baseurl
+        self.username = username
+        self.password = password
+        self.auth()
+
+    def get_headers(self) -> Dict[str, str]:  # pylint: disable=no-self-use
+        return {"X-CSRFToken": self.csrf_token} if self.csrf_token else {}
+
+    def auth(self) -> None:
         """
         Login to get CSRF token and cookies.
         """
-        response = self.session.get(baseurl / "login/")
+        data = {"username": self.username, "password": self.password}
+
+        response = self.session.get(self.baseurl / "login/")
         soup = BeautifulSoup(response.text, "html.parser")
         input_ = soup.find("input", {"id": "csrf_token"})
         csrf_token = input_["value"] if input_ else None
-
-        data = {"username": username, "password": password}
-
         if csrf_token:
-            self.headers["X-CSRFToken"] = csrf_token
+            self.session.headers["X-CSRFToken"] = csrf_token
             data["csrf_token"] = csrf_token
+            self.csrf_token = csrf_token
 
         # set cookies
-        self.session.post(baseurl / "login/", data=data)
+        self.session.post(self.baseurl / "login/", data=data)

--- a/src/preset_cli/auth/preset.py
+++ b/src/preset_cli/auth/preset.py
@@ -11,6 +11,12 @@ from preset_cli.auth.lib import get_access_token, get_credentials_path
 from preset_cli.auth.main import Auth
 
 
+class JWTTokenError(Exception):
+    """
+    Exception raised when fetching the JWT fails.
+    """
+
+
 class PresetAuth(Auth):  # pylint: disable=too-few-public-methods
     """
     Auth via Preset access token and secret.
@@ -33,7 +39,10 @@ class PresetAuth(Auth):  # pylint: disable=too-few-public-methods
         """
         Fetch the JWT and store it.
         """
-        self.token = get_access_token(self.baseurl, self.api_token, self.api_secret)
+        try:
+            self.token = get_access_token(self.baseurl, self.api_token, self.api_secret)
+        except Exception as ex:  # pylint: disable=broad-except
+            raise JWTTokenError("Unable to fetch JWT") from ex
 
     @classmethod
     def from_stored_credentials(cls) -> "PresetAuth":

--- a/src/preset_cli/auth/preset.py
+++ b/src/preset_cli/auth/preset.py
@@ -1,0 +1,50 @@
+"""
+Preset auth.
+"""
+
+from typing import Dict
+
+import yaml
+from yarl import URL
+
+from preset_cli.auth.lib import get_access_token, get_credentials_path
+from preset_cli.auth.main import Auth
+
+
+class PresetAuth(Auth):  # pylint: disable=too-few-public-methods
+    """
+    Auth via Preset access token and secret.
+
+    Automatically refreshes the JWT as needed.
+    """
+
+    def __init__(self, baseurl: URL, api_token: str, api_secret: str):
+        super().__init__()
+
+        self.baseurl = baseurl
+        self.api_token = api_token
+        self.api_secret = api_secret
+        self.auth()
+
+    def get_headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {self.token}"}
+
+    def auth(self) -> None:
+        """
+        Fetch the JWT and store it.
+        """
+        self.token = get_access_token(self.baseurl, self.api_token, self.api_secret)
+
+    @classmethod
+    def from_stored_credentials(cls) -> "PresetAuth":
+        """
+        Build auth from stored credentials.
+        """
+        credentials_path = get_credentials_path()
+        if not credentials_path.exists():
+            raise Exception(f"Could not load credentials from {credentials_path}")
+
+        with open(credentials_path, encoding="utf-8") as input_:
+            credentials = yaml.load(input_, Loader=yaml.SafeLoader)
+
+        return PresetAuth(**credentials)

--- a/src/preset_cli/auth/token.py
+++ b/src/preset_cli/auth/token.py
@@ -7,7 +7,7 @@ from typing import Dict
 from preset_cli.auth.main import Auth
 
 
-class TokenAuth(Auth):  # pylint: disable=too-few-public-methods
+class TokenAuth(Auth):  # pylint: disable=too-few-public-methods, abstract-method
     """
     Auth via a token.
     """

--- a/src/preset_cli/cli/superset/sync/dbt/exposures.py
+++ b/src/preset_cli/cli/superset/sync/dbt/exposures.py
@@ -57,7 +57,7 @@ def get_dashboard_depends_on(
 
     url = client.baseurl / "api/v1/dashboard" / str(dashboard["id"]) / "datasets"
 
-    session = client.auth.get_session()
+    session = client.auth.session
     headers = client.auth.get_headers()
     response = session.get(url, headers=headers)
     response.raise_for_status()
@@ -102,7 +102,7 @@ def sync_exposures(  # pylint: disable=too-many-locals
     for dataset in datasets:
         url = client.baseurl / "api/v1/dataset" / str(dataset["id"]) / "related_objects"
 
-        session = client.auth.get_session()
+        session = client.auth.session
         headers = client.auth.get_headers()
         response = session.get(url, headers=headers)
         response.raise_for_status()

--- a/tests/auth/jwt_test.py
+++ b/tests/auth/jwt_test.py
@@ -44,10 +44,6 @@ def test_jwt_auth_from_stored_credentials(mocker: MockerFixture) -> None:
         api_secret="SECRET",
     )
 
-    # can also pass a URL
-    auth = JWTAuth.from_stored_credentials()
-    assert auth.token == "JWT_TOKEN"
-
     # test for error
     get_credentials_path().exists.return_value = False
     with pytest.raises(Exception) as excinfo:

--- a/tests/auth/main_test.py
+++ b/tests/auth/main_test.py
@@ -3,6 +3,7 @@ Test authentication mechanisms.
 """
 
 from pytest_mock import MockerFixture
+from requests_mock.mocker import Mocker
 
 from preset_cli.auth.main import Auth
 
@@ -11,7 +12,20 @@ def test_auth(mocker: MockerFixture) -> None:
     """
     Tests for the base class ``Auth``.
     """
-    requests = mocker.patch("preset_cli.auth.main.requests")
+    # pylint: disable=invalid-name
+    Session = mocker.patch("preset_cli.auth.main.Session")
 
     auth = Auth()
-    assert auth.get_session() == requests.Session()
+    assert auth.session == Session()
+
+
+def test_reauth(requests_mock: Mocker) -> None:
+    """
+    Test the ``reauth`` hook when authentication fails.
+    """
+    requests_mock.get("http://example.org/", status_code=401)
+
+    # the base class has no reauth
+    auth = Auth()
+    response = auth.session.get("http://example.org/")
+    assert response.status_code == 401

--- a/tests/auth/preset_test.py
+++ b/tests/auth/preset_test.py
@@ -1,0 +1,89 @@
+"""
+Test Preset auth.
+"""
+
+import pytest
+from pytest_mock import MockerFixture
+from requests_mock.mocker import Mocker
+from yarl import URL
+
+from preset_cli.auth.preset import PresetAuth
+
+
+def test_preset_auth(mocker: MockerFixture) -> None:
+    """
+    Test the ``PresetAuth`` authentication mechanism.
+    """
+    mocker.patch("preset_cli.auth.preset.get_access_token", return_value="JWT_TOKEN")
+
+    auth = PresetAuth(URL("http:/api.app.preset.io/"), "TOKEN", "SECRET")
+    assert auth.get_headers() == {"Authorization": "Bearer JWT_TOKEN"}
+
+
+def test_preset_auth_reauth(mocker: MockerFixture, requests_mock: Mocker) -> None:
+    """
+    Test reauthorizing on a 401.
+    """
+    mocker.patch(
+        "preset_cli.auth.preset.get_access_token",
+        side_effect=["JWT_TOKEN1", "JWT_TOKEN2"],
+    )
+    requests_mock.get(
+        "https://api.app.preset.io/",
+        status_code=401,
+    )
+    requests_mock.get(
+        "https://api.app.preset.io/",
+        request_headers={"Authorization": "Bearer JWT_TOKEN1"},
+        status_code=401,
+    )
+    requests_mock.get(
+        "https://api.app.preset.io/",
+        request_headers={"Authorization": "Bearer JWT_TOKEN2"},
+        status_code=200,
+    )
+
+    auth = PresetAuth(URL("https:/api.app.preset.io/"), "TOKEN", "SECRET")
+    print(auth.get_headers())
+    assert auth.get_headers() == {"Authorization": "Bearer JWT_TOKEN1"}
+    response = auth.session.get("https://api.app.preset.io/")
+    assert response.status_code == 200
+    assert auth.get_headers() == {"Authorization": "Bearer JWT_TOKEN2"}
+
+
+def test_preset_auth_from_stored_credentials(mocker: MockerFixture) -> None:
+    """
+    Test instantiating the object from stored credentials
+    """
+    mocker.patch("preset_cli.auth.preset.open")
+
+    get_credentials_path = mocker.patch("preset_cli.auth.preset.get_credentials_path")
+    get_credentials_path().exists.return_value = True
+    get_credentials_path().__str__.return_value = "/path/to/credentials.yaml"
+
+    yaml = mocker.patch("preset_cli.auth.preset.yaml")
+    yaml.load.return_value = {
+        "api_token": "TOKEN",
+        "api_secret": "SECRET",
+        "baseurl": "https://api.app.preset.io/",
+    }
+
+    get_access_token = mocker.patch("preset_cli.auth.preset.get_access_token")
+    get_access_token.return_value = "JWT_TOKEN"
+
+    auth = PresetAuth.from_stored_credentials()
+    assert auth.token == "JWT_TOKEN"
+    get_access_token.assert_called_with(
+        "https://api.app.preset.io/",
+        "TOKEN",
+        "SECRET",
+    )
+
+    # test for error
+    get_credentials_path().exists.return_value = False
+    with pytest.raises(Exception) as excinfo:
+        PresetAuth.from_stored_credentials()
+    assert (
+        str(excinfo.value)
+        == "Could not load credentials from /path/to/credentials.yaml"
+    )

--- a/tests/auth/preset_test.py
+++ b/tests/auth/preset_test.py
@@ -44,7 +44,6 @@ def test_preset_auth_reauth(mocker: MockerFixture, requests_mock: Mocker) -> Non
     )
 
     auth = PresetAuth(URL("https:/api.app.preset.io/"), "TOKEN", "SECRET")
-    print(auth.get_headers())
     assert auth.get_headers() == {"Authorization": "Bearer JWT_TOKEN1"}
     response = auth.session.get("https://api.app.preset.io/")
     assert response.status_code == 200

--- a/tests/cli/main_test.py
+++ b/tests/cli/main_test.py
@@ -1,7 +1,7 @@
 """
 Tests for ``preset_cli.cli.main``.
 """
-# pylint: disable=unused-argument, invalid-name, redefined-outer-name
+# pylint: disable=unused-argument, invalid-name, redefined-outer-name, too-many-lines
 
 from pathlib import Path
 from typing import Any, Dict
@@ -219,7 +219,7 @@ def test_auth_overwrite_expired_credentials(
         return_value=credentials_path,
     )
     get_access_token = mocker.patch(
-        "preset_cli.cli.main.get_access_token",
+        "preset_cli.auth.preset.get_access_token",
         side_effect=Exception("Unable to get access token"),
     )
 
@@ -256,7 +256,7 @@ def test_cmd_handling_failed_creds(
         return_value=credentials_path,
     )
     get_access_token = mocker.patch(
-        "preset_cli.cli.main.get_access_token",
+        "preset_cli.auth.preset.get_access_token",
         side_effect=Exception("Unable to get access token"),
     )
 
@@ -296,13 +296,17 @@ def test_jwt_token_credentials_exist(
         "preset_cli.cli.main.get_credentials_path",
         return_value=credentials_path,
     )
-    mocker.patch("preset_cli.cli.main.get_access_token", return_value="JWT_TOKEN")
-    JWTAuth = mocker.patch("preset_cli.cli.main.JWTAuth")
+    mocker.patch("preset_cli.auth.preset.get_access_token", return_value="JWT_TOKEN")
+    PresetAuth = mocker.patch("preset_cli.cli.main.PresetAuth")
 
     runner = CliRunner()
     result = runner.invoke(preset_cli, ["superset", "--help"], catch_exceptions=False)
     assert result.exit_code == 1
-    JWTAuth.assert_called_with("JWT_TOKEN")
+    PresetAuth.assert_called_with(
+        URL("https://api.app.preset.io/"),
+        "API_TOKEN",
+        "API_SECRET",
+    )
 
 
 def test_jwt_token_invalid_credentials(
@@ -321,7 +325,7 @@ def test_jwt_token_invalid_credentials(
         "preset_cli.cli.main.get_credentials_path",
         return_value=credentials_path,
     )
-    mocker.patch("preset_cli.cli.main.get_access_token", return_value="JWT_TOKEN")
+    mocker.patch("preset_cli.auth.preset.get_access_token", return_value="JWT_TOKEN")
 
     runner = CliRunner()
     result = runner.invoke(preset_cli, ["superset", "--help"], catch_exceptions=False)
@@ -345,13 +349,17 @@ def test_jwt_token_prompt_for_credentials(
     getpass = mocker.patch("preset_cli.cli.main.getpass")
     getpass.getpass.return_value = "API_SECRET"
     mocker.patch("preset_cli.cli.main.store_credentials")
-    mocker.patch("preset_cli.cli.main.get_access_token", return_value="JWT_TOKEN")
-    JWTAuth = mocker.patch("preset_cli.cli.main.JWTAuth")
+    mocker.patch("preset_cli.auth.preset.get_access_token", return_value="JWT_TOKEN")
+    PresetAuth = mocker.patch("preset_cli.cli.main.PresetAuth")
 
     runner = CliRunner()
     result = runner.invoke(preset_cli, ["superset", "--help"], catch_exceptions=False)
     assert result.exit_code == 1
-    JWTAuth.assert_called_with("JWT_TOKEN")
+    PresetAuth.assert_called_with(
+        URL("https://api.app.preset.io/"),
+        "API_TOKEN",
+        "API_SECRET",
+    )
 
 
 def test_jwt_token_credentials_passed(
@@ -361,8 +369,8 @@ def test_jwt_token_credentials_passed(
     """
     Test the command when the credentials are stored.
     """
-    mocker.patch("preset_cli.cli.main.get_access_token", return_value="JWT_TOKEN")
-    JWTAuth = mocker.patch("preset_cli.cli.main.JWTAuth")
+    mocker.patch("preset_cli.auth.preset.get_access_token", return_value="JWT_TOKEN")
+    PresetAuth = mocker.patch("preset_cli.cli.main.PresetAuth")
 
     runner = CliRunner()
     result = runner.invoke(
@@ -378,7 +386,11 @@ def test_jwt_token_credentials_passed(
         catch_exceptions=False,
     )
     assert result.exit_code == 1
-    JWTAuth.assert_called_with("JWT_TOKEN")
+    PresetAuth.assert_called_with(
+        URL("https://api.app.preset.io/"),
+        "API_TOKEN",
+        "API_SECRET",
+    )
 
 
 def test_workspaces(mocker: MockerFixture) -> None:

--- a/tests/cli/superset/sync/dbt/exposures_test.py
+++ b/tests/cli/superset/sync/dbt/exposures_test.py
@@ -501,7 +501,7 @@ def test_get_dashboard_depends_on(mocker: MockerFixture) -> None:
     """
     client = mocker.MagicMock()
     client.get_dataset.return_value = dataset_response
-    session = client.auth.get_session()
+    session = client.auth.session
     session.get().json.return_value = datasets_response
 
     depends_on = get_dashboard_depends_on(client, dashboard_response["result"], {})
@@ -516,7 +516,7 @@ def test_get_dashboard_depends_on_no_extra(mocker: MockerFixture) -> None:
     modified_dataset_response = copy.deepcopy(dataset_response)
     modified_dataset_response["result"]["extra"] = None  # type: ignore
     client.get_dataset.return_value = modified_dataset_response
-    session = client.auth.get_session()
+    session = client.auth.session
     session.get().json.return_value = datasets_response
 
     depends_on = get_dashboard_depends_on(client, dashboard_response["result"], {})
@@ -531,7 +531,7 @@ def test_get_dashboard_depends_on_invalid_extra(mocker: MockerFixture) -> None:
     modified_dataset_response = copy.deepcopy(dataset_response)
     modified_dataset_response["result"]["extra"] = "{[("  # type: ignore
     client.get_dataset.return_value = modified_dataset_response
-    session = client.auth.get_session()
+    session = client.auth.session
     session.get().json.return_value = datasets_response
 
     depends_on = get_dashboard_depends_on(client, dashboard_response["result"], {})
@@ -574,7 +574,7 @@ def test_sync_exposures(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     client.baseurl = URL("https://superset.example.org/")
     client.get_chart.return_value = chart_response
     client.get_dashboard.return_value = dashboard_response
-    session = client.auth.get_session()
+    session = client.auth.session
     session.get().json.return_value = related_objects_response
     mocker.patch(
         "preset_cli.cli.superset.sync.dbt.exposures.get_dashboard_depends_on",
@@ -631,7 +631,7 @@ def test_sync_exposures_no_charts_no_dashboards(
 
     client = mocker.MagicMock()
     client.baseurl = URL("https://superset.example.org/")
-    session = client.auth.get_session()
+    session = client.auth.session
     no_related_objects_response = copy.deepcopy(related_objects_response)
     no_related_objects_response["charts"]["result"] = []
     no_related_objects_response["dashboards"]["result"] = []
@@ -677,7 +677,7 @@ def test_get_dashboard_depends_on_from_dataset(mocker: MockerFixture) -> None:
     modified_dataset_response = copy.deepcopy(dataset_response)
     modified_dataset_response["result"]["extra"] = None  # type: ignore
     client.get_dataset.return_value = modified_dataset_response
-    session = client.auth.get_session()
+    session = client.auth.session
     session.get().json.return_value = datasets_response
 
     key = ModelKey("public", "messages_channels")


### PR DESCRIPTION
A customer needs to run a really big import (~12 hours), but the JWT is only valid for 5. So I added some logic to refresh authentication (across all mechanisms) whenever needed.

The main auth class (simplified) now looks like this:

```python
class Auth:  # pylint: disable=too-few-public-methods
    def __init__(self):
        self.session = Session()

        # call ``self.reauth`` after every request
        self.session.hooks["response"].append(self.reauth)

    def auth(self) -> None:
        raise NotImplementedError("Must be implemented for reauthorizing")

    def reauth(self, r: Response, *args: Any, **kwargs: Any) -> Response:
        if r.status_code != 401:
            return r

        # if the response was 401, auth and try again
        try:
            self.auth()
        except NotImplementedError:
            return r

        self.session.headers.update(self.get_headers())
        r.request.headers.update(self.get_headers())
        return self.session.send(r.request, verify=False)
```

On `__init__` it attaches a hook to the session, calling `reauth` **after** every request. On `reauth`, if the response was a 401 and the derived class implements the `auth` method, then `auth` gets called to refresh cookies/tokens, and the request is resent.

This PR implements `auth` for the Preset and the username:password authentication mechanisms.