### PR TITLE
feat (native): add checkpoint file

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -31,7 +31,7 @@ class PostelSchema(Schema):
     """
     Be liberal in what you accept, and conservative in what you send.
 
-    A schema that allows unknown fields. This way if they API returns new fields that
+    A schema that allows unknown fields. This way if the API returns new fields that
     the client is not expecting no errors will be thrown when validating the payload.
     """
 


### PR DESCRIPTION
When running `import_resources_individually`, write progress to a file called `checkpoint.log`. If the import fails, the file is used to skipped already imported assets on the next run.