### PR TITLE
feat (dbt): allow syncing only exposures

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -81,7 +81,7 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-locals
     import_db: bool = False,
     disallow_edits: bool = True,
     external_url_prefix: str = "",
-    exposures_only: bool = True,
+    exposures_only: bool = False,
 ) -> None:
     """
     Sync models/metrics from dbt Core to Superset and charts/dashboards to dbt exposures.
@@ -310,7 +310,7 @@ def dbt_cloud(  # pylint: disable=too-many-arguments, too-many-locals
     job_id: Optional[int] = None,
     disallow_edits: bool = True,
     external_url_prefix: str = "",
-    exposures_only: bool = True,
+    exposures_only: bool = False,
 ) -> None:
     """
     Sync models/metrics from dbt Cloud to Superset.

--- a/src/preset_cli/cli/superset/sync/dbt/exposures.py
+++ b/src/preset_cli/cli/superset/sync/dbt/exposures.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, NamedTuple, Optional
 
 import yaml
 
-from preset_cli.api.clients.dbt import ModelSchema
 from preset_cli.api.clients.superset import SupersetClient
 
 # XXX: DashboardResponseType and DatasetResponseType
@@ -85,7 +84,7 @@ def sync_exposures(  # pylint: disable=too-many-locals
     client: SupersetClient,
     exposures_path: Path,
     datasets: List[Any],
-    models: List[ModelSchema],
+    model_map: Dict[ModelKey, str],
 ) -> None:
     """
     Write dashboards back to dbt as exposures.
@@ -93,11 +92,6 @@ def sync_exposures(  # pylint: disable=too-many-locals
     exposures = []
     charts_ids = set()
     dashboards_ids = set()
-
-    model_map = {
-        ModelKey(model["schema"], model["name"]): f'ref({model["name"]})'
-        for model in models
-    }
 
     for dataset in datasets:
         url = client.baseurl / "api/v1/dataset" / str(dataset["id"]) / "related_objects"

--- a/tests/cli/superset/sync/dbt/exposures_test.py
+++ b/tests/cli/superset/sync/dbt/exposures_test.py
@@ -586,7 +586,7 @@ def test_sync_exposures(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     )
 
     datasets = [dataset_response["result"]]
-    sync_exposures(client, exposures, datasets, [])
+    sync_exposures(client, exposures, datasets, {})
 
     with open(exposures, encoding="utf-8") as input_:
         contents = yaml.load(input_, Loader=yaml.SafeLoader)
@@ -638,7 +638,7 @@ def test_sync_exposures_no_charts_no_dashboards(
     session.get().json.return_value = no_related_objects_response
 
     datasets = [dataset_response["result"]]
-    sync_exposures(client, exposures, datasets, [])
+    sync_exposures(client, exposures, datasets, {})
 
     with open(exposures, encoding="utf-8") as input_:
         contents = yaml.load(input_, Loader=yaml.SafeLoader)


### PR DESCRIPTION
Allow syncing only exposures from Preset workspaces to a YAML file.

This now works with both dbt Cloud and dbt Core:

```bash
$ preset-cli superset sync dbt-core ... --exposures=exposures.yaml --exposures-only
$ preset-cli superset sync dbt-cloud ... --exposures=exposures.yaml --exposures-only
```

The datasets don't have to be created via the CLI for the exposure discovery to work. The command will look at all models (filtered by `--select` and `--excluded`, if set) and figure out which datasets correspond to them based on the the database, schema, and table name.