### PR TITLE
fix: preserve is_dttm on column update

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -149,14 +149,23 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
             client.update_dataset(dataset["id"], override_columns=False, **update)
 
         # update column descriptions
-        update = {
-            "columns": [
-                {"column_name": name, "description": column.get("description", "")}
-                for name, column in model.get("columns", {}).items()
-            ],
-        }
-        if update["columns"]:
-            client.update_dataset(dataset["id"], override_columns=True, **update)
+        if columns := model.get("columns"):
+            current_columns = client.get_dataset(dataset["id"])["columns"]
+            for column in current_columns:
+                name = column["column_name"]
+                if name in columns:
+                    column["description"] = columns[name].get("description", "")
+
+                # remove columns that are not part of the update payload
+                for key in ("changed_on", "created_on", "type_generic"):
+                    if key in column:
+                        del column[key]
+
+            client.update_dataset(
+                dataset["id"],
+                override_columns=True,
+                columns=current_columns,
+            )
 
         datasets.append(dataset)
 

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -58,6 +58,12 @@ def test_sync_datasets_new(mocker: MockerFixture) -> None:
     client = mocker.MagicMock()
     client.get_datasets.return_value = []
     client.create_dataset.side_effect = [{"id": 1}, {"id": 2}, {"id": 3}]
+    client.get_dataset.return_value = {
+        "columns": [
+            {"column_name": "id", "is_dttm": False, "type_generic": "INTEGER"},
+            {"column_name": "ts", "is_dttm": True, "type_generic": "TIMESTAMP"},
+        ],
+    }
 
     sync_datasets(
         client=client,
@@ -109,6 +115,11 @@ def test_sync_datasets_new(mocker: MockerFixture) -> None:
                     {
                         "column_name": "id",
                         "description": "Primary key",
+                        "is_dttm": False,
+                    },
+                    {
+                        "column_name": "ts",
+                        "is_dttm": True,
                     },
                 ],
             ),
@@ -123,6 +134,9 @@ def test_sync_datasets_no_metrics(mocker: MockerFixture) -> None:
     client = mocker.MagicMock()
     client.get_datasets.return_value = []
     client.create_dataset.side_effect = [{"id": 1}, {"id": 2}, {"id": 3}]
+    client.get_dataset.return_value = {
+        "columns": [{"column_name": "id", "is_dttm": False}],
+    }
 
     sync_datasets(
         client=client,
@@ -160,6 +174,7 @@ def test_sync_datasets_no_metrics(mocker: MockerFixture) -> None:
                     {
                         "column_name": "id",
                         "description": "Primary key",
+                        "is_dttm": False,
                     },
                 ],
             ),
@@ -201,6 +216,9 @@ def test_sync_datasets_existing(mocker: MockerFixture) -> None:
     """
     client = mocker.MagicMock()
     client.get_datasets.side_effect = [[{"id": 1}], [{"id": 2}], [{"id": 3}]]
+    client.get_dataset.return_value = {
+        "columns": [{"column_name": "id", "is_dttm": False}],
+    }
 
     sync_datasets(
         client=client,
@@ -248,6 +266,7 @@ def test_sync_datasets_existing(mocker: MockerFixture) -> None:
                     {
                         "column_name": "id",
                         "description": "Primary key",
+                        "is_dttm": False,
                     },
                 ],
             ),
@@ -280,6 +299,9 @@ def test_sync_datasets_external_url(mocker: MockerFixture) -> None:
     """
     client = mocker.MagicMock()
     client.get_datasets.side_effect = [[{"id": 1}], [{"id": 2}], [{"id": 3}]]
+    client.get_dataset.return_value = {
+        "columns": [{"column_name": "id", "is_dttm": False}],
+    }
 
     sync_datasets(
         client=client,
@@ -331,6 +353,7 @@ def test_sync_datasets_external_url(mocker: MockerFixture) -> None:
                     {
                         "column_name": "id",
                         "description": "Primary key",
+                        "is_dttm": False,
                     },
                 ],
             ),


### PR DESCRIPTION
When updating columns descriptions we're not passing other metadata like `is_dttm`, which causes temporal columns to be marked as non-temporal after a sync.

I fixed it by fetching the column definitions, applying updates from dbt, and doing the column update.

Closes #152