### PR TITLE
fix: ignore missing users in export-roles

### DIFF
--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -789,6 +789,7 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
                     user_email_map[int(option.attrs["value"])]
                     for option in soup.find("select", id="user").find_all("option")
                     if "selected" in option.attrs
+                    and int(option.attrs["value"]) in user_email_map
                 ]
 
                 yield {


### PR DESCRIPTION
When exporting roles from a Preset workspace (or Superset instance), ignore users which we can't find an email for (since the export is based on email).