### PR TITLE
fix: ensure is_active is true

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -165,6 +165,11 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
                     if key in column:
                         del column[key]
 
+                # for some reason this is being sent as null sometimes
+                # https://github.com/preset-io/backend-sdk/issues/163
+                if "is_active" in column and column["is_active"] is None:
+                    del column["is_active"]
+
             client.update_dataset(
                 dataset["id"],
                 override_columns=True,

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -217,7 +217,7 @@ def test_sync_datasets_existing(mocker: MockerFixture) -> None:
     client = mocker.MagicMock()
     client.get_datasets.side_effect = [[{"id": 1}], [{"id": 2}], [{"id": 3}]]
     client.get_dataset.return_value = {
-        "columns": [{"column_name": "id", "is_dttm": False}],
+        "columns": [{"column_name": "id", "is_dttm": False, "is_active": None}],
     }
 
     sync_datasets(


### PR DESCRIPTION
For some reason the CLI is pushing `is_active=null` to the API when updating columns, something that should never happen:

```
ERROR: preset_cli.lib: {"message":{"columns":{"0":{"is_active":["Field may not be null."]},"1":{"is_active":["Field may not be null."]},"2":{"is_active":["Field may not be null."]},"3":{"is_active":["Field may not be null."]},"4":{"is_active":["Field may not be null."]},"5":{"is_active":["Field may not be null."]}}}} 
```

I changed the CLI so that when a column has `is_active` set to `None` we remove it from the update, preserving the existing value.