### PR TITLE
Add support for Secondary Contributor (new Workspace Role)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
 #     ]
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.7.0
+  rev: 5.11.5
   hooks:
   - id: isort
 

--- a/src/preset_cli/cli/main.py
+++ b/src/preset_cli/cli/main.py
@@ -40,6 +40,7 @@ def get_status_icon(status: str) -> str:
         "UNKNOWN": "❓",
         "ERROR": "❗️",
         "UPGRADING": "⤴️",
+        "HIBERNATED": "💤",
     }
     return icons.get(status, "❓")
 
@@ -85,6 +86,7 @@ def is_help() -> bool:
 workspace_role_identifiers = {
     "workspace admin": "Admin",
     "primary contributor": "PresetAlpha",
+    "secondary contributor": "PresetBeta",
     "limited contributor": "PresetGamma",
     "viewer": "PresetReportsOnly",
     "dashboard viewer": "PresetDashboardsOnly",


### PR DESCRIPTION
* Preset has recently introduced a new Workspace Role: **Secondary Contributor**. Added support for this role (`PresetBeta`).
* Also added an emoji for Workspaces in hibernated status.