### PR TITLE
fix: use table alias when creating dataset

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -50,7 +50,7 @@ def create_dataset(
         kwargs = {
             "database": database["id"],
             "schema": model["schema"],
-            "table_name": model["name"],
+            "table_name": model.get("alias") or model["name"],
         }
     else:
         engine = create_engine(url)
@@ -59,7 +59,7 @@ def create_dataset(
         kwargs = {
             "database": database["id"],
             "schema": model["schema"],
-            "table_name": model["name"],
+            "table_name": model.get("alias") or model["name"],
             "sql": f"SELECT * FROM {source}",
         }
 
@@ -85,7 +85,7 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
         filters = {
             "database": OneToMany(database["id"]),
             "schema": model["schema"],
-            "table_name": model["name"],
+            "table_name": model.get("alias") or model["name"],
         }
         existing = client.get_datasets(**filters)
         if len(existing) > 1:

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -127,6 +127,96 @@ def test_sync_datasets_new(mocker: MockerFixture) -> None:
     )
 
 
+def test_sync_datasets_with_alias(mocker: MockerFixture) -> None:
+    """
+    Test ``sync_datasets`` when datasets has an alias.
+    """
+    client = mocker.MagicMock()
+    client.get_datasets.return_value = []
+    client.create_dataset.side_effect = [{"id": 1}, {"id": 2}, {"id": 3}]
+    client.get_dataset.return_value = {
+        "columns": [
+            {"column_name": "id", "is_dttm": False, "type_generic": "INTEGER"},
+            {"column_name": "ts", "is_dttm": True, "type_generic": "TIMESTAMP"},
+        ],
+    }
+
+    models_with_alias: List[ModelSchema] = [
+        model_schema.load(
+            {
+                "alias": "model_alias",
+                "database": "examples_dev",
+                "schema": "public",
+                "description": "",
+                "meta": {},
+                "name": "messages_channels",
+                "unique_id": "model.superset_examples.messages_channels",
+                "columns": {"id": {"description": "Primary key"}},
+            },
+        ),
+    ]
+    sync_datasets(
+        client=client,
+        models=models_with_alias,
+        metrics=metrics,
+        database={"id": 1, "sqlalchemy_uri": "postgresql://user@host/examples_dev"},
+        disallow_edits=False,
+        external_url_prefix="",
+    )
+    client.create_dataset.assert_has_calls(
+        [
+            mock.call(database=1, schema="public", table_name="model_alias"),
+        ],
+    )
+    client.update_dataset.assert_has_calls(
+        [
+            mock.call(
+                1,
+                override_columns=True,
+                description="",
+                extra=json.dumps(
+                    {
+                        "unique_id": "model.superset_examples.messages_channels",
+                        "depends_on": "ref('messages_channels')",
+                        "certification": {"details": "This table is produced by dbt"},
+                    },
+                ),
+                is_managed_externally=False,
+                metrics=[],
+            ),
+            mock.call(
+                1,
+                override_columns=False,
+                metrics=[
+                    {
+                        "expression": "COUNT(*)",
+                        "metric_name": "cnt",
+                        "metric_type": "count",
+                        "verbose_name": "",
+                        "description": "",
+                        "extra": "{}",
+                    },
+                ],
+            ),
+            mock.call(
+                1,
+                override_columns=True,
+                columns=[
+                    {
+                        "column_name": "id",
+                        "description": "Primary key",
+                        "is_dttm": False,
+                    },
+                    {
+                        "column_name": "ts",
+                        "is_dttm": True,
+                    },
+                ],
+            ),
+        ],
+    )
+
+
 def test_sync_datasets_no_metrics(mocker: MockerFixture) -> None:
     """
     Test ``sync_datasets`` when no datasets exist yet.


### PR DESCRIPTION
Models in dbt can have alias, eg:

```sql
-- foo.sql
{{ config (alias = 'model_alias') }}
SELECT ...
```

In this case, instead of the table created being called `foo` it will be called `model_alias`. When creating the Superset dataset pointing to the table we should use the alias in this case.

Closes https://github.com/preset-io/backend-sdk/issues/173.