### PR TITLE
(chore) Supporting dbt sync without updating the db connection configuration on Superset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -352,7 +352,7 @@ Example:
             superset:
               database_name: Postgres - Production
 
-If  ``--import-db`` was passed and a database connection was found on the Workspace, the operation would update the connection configuration with the dbt connection settings. 
+If  ``--import-db`` was passed and a database connection was found on the workspace, the operation would update the connection configuration with the dbt connection settings.
 
 If you're using dbt Cloud you can instead pass a job ID and a `service account access token <https://cloud.getdbt.com/#/accounts/72449/settings/service-tokens/new/>`_:
 

--- a/README.rst
+++ b/README.rst
@@ -312,7 +312,7 @@ If you're using dbt Core you can point the CLI to your compiled manifest and you
 
    % preset-cli --workspaces=https://abcdef12.us1a.app.preset.io/ \
    > superset sync dbt-core /path/to/dbt/my_project/target/manifest.json \
-   > --project=my_project --target=dev --profile=${HOME}/.dbt/profiles.yml \
+   > --project=my_project --target=dev --profiles=${HOME}/.dbt/profiles.yml \
    > --exposures=/path/to/dbt/my_project/models/exposures.yaml \
    > --import-db \
    > --external-url-prefix=http://localhost:8080/
@@ -351,6 +351,8 @@ Example:
           meta:
             superset:
               database_name: Postgres - Production
+
+If  ``--import-db`` was passed and a database connection was found on the Workspace, the operation would update the connection configuration with the dbt connection settings. 
 
 If you're using dbt Cloud you can instead pass a job ID and a `service account access token <https://cloud.getdbt.com/#/accounts/72449/settings/service-tokens/new/>`_:
 

--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -40,7 +40,7 @@ from preset_cli.exceptions import DatabaseNotFoundError
     "--import-db",
     is_flag=True,
     default=False,
-    help="Import database to Superset",
+    help="Import (or update) the database connection to Superset",
 )
 @click.option(
     "--disallow-edits",

--- a/src/preset_cli/cli/superset/sync/dbt/databases.py
+++ b/src/preset_cli/cli/superset/sync/dbt/databases.py
@@ -53,11 +53,11 @@ def sync_database(  # pylint: disable=too-many-locals, too-many-arguments
     if base_url and "external_url" not in meta:
         meta["external_url"] = str(base_url.with_fragment("!/overview"))
 
-    if databases:
-        _logger.info("Found an existing database, updating it")
+    if import_db and databases:
+        _logger.info("Found an existing database connection, updating it")
         database = databases[0]
-
         meta.pop("uuid", None)
+
         database = client.update_database(
             database_id=database["id"],
             database_name=database_name,
@@ -66,10 +66,12 @@ def sync_database(  # pylint: disable=too-many-locals, too-many-arguments
             sqlalchemy_uri=connection_params["sqlalchemy_uri"],
             **meta,
         )
-    elif not import_db:
-        raise DatabaseNotFoundError()
-    else:
-        _logger.info("No database found, creating it")
+
+        database["sqlalchemy_uri"] = connection_params["sqlalchemy_uri"]
+
+    elif import_db:
+        _logger.info("No database connection found, creating it")
+
         database = client.create_database(
             database_name=database_name,
             is_managed_externally=disallow_edits,
@@ -78,6 +80,14 @@ def sync_database(  # pylint: disable=too-many-locals, too-many-arguments
             **meta,
         )
 
-    database["sqlalchemy_uri"] = connection_params["sqlalchemy_uri"]
+        database["sqlalchemy_uri"] = connection_params["sqlalchemy_uri"]
+
+    elif databases:
+        _logger.info("Found an existing database connection, using it")
+        database = databases[0]
+        database["sqlalchemy_uri"] = client.get_database(database["id"])["sqlalchemy_uri"]
+
+    else:
+        raise DatabaseNotFoundError()
 
     return database

--- a/src/preset_cli/cli/superset/sync/dbt/databases.py
+++ b/src/preset_cli/cli/superset/sync/dbt/databases.py
@@ -85,7 +85,9 @@ def sync_database(  # pylint: disable=too-many-locals, too-many-arguments
     elif databases:
         _logger.info("Found an existing database connection, using it")
         database = databases[0]
-        database["sqlalchemy_uri"] = client.get_database(database["id"])["sqlalchemy_uri"]
+        database["sqlalchemy_uri"] = client.get_database(database["id"])[
+            "sqlalchemy_uri"
+        ]
 
     else:
         raise DatabaseNotFoundError()

--- a/tests/cli/superset/sync/dbt/databases_test.py
+++ b/tests/cli/superset/sync/dbt/databases_test.py
@@ -392,7 +392,10 @@ def test_sync_database_new_no_import(mocker: MockerFixture, fs: FakeFilesystem) 
         )
 
 
-def test_sync_database_reuse_connection(mocker: MockerFixture, fs: FakeFilesystem) -> None:
+def test_sync_database_reuse_connection(
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
+) -> None:
     """
     Test ``sync_database`` when the connection already exists and --import-db wasn't passed.
     """


### PR DESCRIPTION
Currently, the CLI would always update the DB connection configuration on the Workspace using the information from the `profiles.yml` file (regardless if `--import-db` was passed or not). The flag was only validated in case **no database connection was found**.

This PR introduces the ability to perform a dbt sync without updating the DB connection. This is very useful in case the dbt configuration uses different credentials, or even a different authentication method that might not be supported by Superset. 