### PR TITLE
feat(dbt): sync column label

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -159,6 +159,7 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
                 name = column["column_name"]
                 if name in columns:
                     column["description"] = columns[name].get("description", "")
+                    column["label"] = columns[name].get("label", "")
 
                 # remove columns that are not part of the update payload
                 for key in ("changed_on", "created_on", "type_generic"):

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -45,7 +45,7 @@ models: List[ModelSchema] = [
             "meta": {},
             "name": "messages_channels",
             "unique_id": "model.superset_examples.messages_channels",
-            "columns": {"id": {"description": "Primary key"}},
+            "columns": {"id": {"description": "Primary key", "label": "some label"}},
         },
     ),
 ]
@@ -115,6 +115,7 @@ def test_sync_datasets_new(mocker: MockerFixture) -> None:
                     {
                         "column_name": "id",
                         "description": "Primary key",
+                        "label": "some label",
                         "is_dttm": False,
                     },
                     {
@@ -205,6 +206,7 @@ def test_sync_datasets_with_alias(mocker: MockerFixture) -> None:
                     {
                         "column_name": "id",
                         "description": "Primary key",
+                        "label": "",
                         "is_dttm": False,
                     },
                     {
@@ -264,6 +266,7 @@ def test_sync_datasets_no_metrics(mocker: MockerFixture) -> None:
                     {
                         "column_name": "id",
                         "description": "Primary key",
+                        "label": "some label",
                         "is_dttm": False,
                     },
                 ],
@@ -356,6 +359,7 @@ def test_sync_datasets_existing(mocker: MockerFixture) -> None:
                     {
                         "column_name": "id",
                         "description": "Primary key",
+                        "label": "some label",
                         "is_dttm": False,
                     },
                 ],
@@ -443,6 +447,7 @@ def test_sync_datasets_external_url(mocker: MockerFixture) -> None:
                     {
                         "column_name": "id",
                         "description": "Primary key",
+                        "label": "some label",
                         "is_dttm": False,
                     },
                 ],


### PR DESCRIPTION
We were not syncing the column labels, only their descriptions.