### PR TITLE
Do not build SQLAlchemy URI in case the database won't be imported/modified

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/databases.py
+++ b/src/preset_cli/cli/superset/sync/dbt/databases.py
@@ -49,10 +49,10 @@ def sync_database(  # pylint: disable=too-many-locals, too-many-arguments
         meta["external_url"] = str(base_url.with_fragment("!/overview"))
 
     if import_db:
-        if "connection_params" in meta:
-            connection_params = meta.pop("connection_params")
-        else:
-            connection_params = build_sqlalchemy_params(target)
+        connection_params = meta.pop(
+            "connection_params",
+            build_sqlalchemy_params(target),
+        )
 
         if databases:
             _logger.info("Found an existing database connection, updating it")

--- a/src/preset_cli/cli/superset/sync/dbt/databases.py
+++ b/src/preset_cli/cli/superset/sync/dbt/databases.py
@@ -49,12 +49,11 @@ def sync_database(  # pylint: disable=too-many-locals, too-many-arguments
         meta["external_url"] = str(base_url.with_fragment("!/overview"))
 
     if import_db:
-
         if "connection_params" in meta:
             connection_params = meta.pop("connection_params")
         else:
             connection_params = build_sqlalchemy_params(target)
-        
+
         if databases:
             _logger.info("Found an existing database connection, updating it")
             database = databases[0]


### PR DESCRIPTION
Currently, for the dbt sync the database connection would only be created/updated in Superset in case `--import-db` was passed. However, the CLI was still building the SQLAlchemy URI regardless of this flag, which would still throw an error in case the DB authentication method in DBT is un-supported in Preset. 

With this PR, `build_sqlalchemy_params()` is only called in case `import_db == True`.