### PR TITLE
feat: allow passing a certification payload

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -73,6 +73,7 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
     database: Any,
     disallow_edits: bool,
     external_url_prefix: str,
+    certification=None,
 ) -> List[Any]:
     """
     Read the dbt manifest and import models as datasets with metrics.
@@ -105,9 +106,8 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
         extra = {
             "unique_id": model["unique_id"],
             "depends_on": "ref('{name}')".format(**model),
-            "certification": {
-                "details": "This table is produced by dbt",
-            },
+            "certification": certification
+            or {"details": "This table is produced by dbt"},
         }
 
         dataset_metrics = []

--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -6,7 +6,7 @@ Sync dbt datasets/metrics to Superset.
 
 import json
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from sqlalchemy.engine import create_engine
 from sqlalchemy.engine.url import URL as SQLAlchemyURL
@@ -73,7 +73,7 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
     database: Any,
     disallow_edits: bool,
     external_url_prefix: str,
-    certification=None,
+    certification: Optional[Dict[str, Any]] = None,
 ) -> List[Any]:
     """
     Read the dbt manifest and import models as datasets with metrics.


### PR DESCRIPTION
Allow passing a certification payload when syncing datasets from dbt.