### PR TITLE
Adding config option for filtering models

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -535,7 +535,7 @@ class ModelSchema(PostelSchema):
     unique_id = fields.String(data_key="uniqueId")
     tags = fields.List(fields.String())
     columns = fields.Raw()
-    config = fields.Dict(fields.String(), fields.Raw())
+    config = fields.Dict(fields.String(), fields.Raw(allow_none=True))
 
 
 class FilterSchema(PostelSchema):

--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -535,6 +535,7 @@ class ModelSchema(PostelSchema):
     unique_id = fields.String(data_key="uniqueId")
     tags = fields.List(fields.String())
     columns = fields.Raw()
+    config = fields.Dict(fields.String(), fields.Raw())
 
 
 class FilterSchema(PostelSchema):

--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -299,7 +299,7 @@ def filter_models(models: List[ModelSchema], condition: str) -> List[ModelSchema
 
     if condition.startswith("config"):
         filtered_models = []
-        config_key, config_value = re.split(r'[.:]', condition)[1:]
+        config_key, config_value = re.split(r"[.:]", condition)[1:]
         for model in models:
             if model.get("config", {}).get(config_key) == config_value:
                 filtered_models.append(model)

--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -297,6 +297,14 @@ def filter_models(models: List[ModelSchema], condition: str) -> List[ModelSchema
         tag = condition.split(":", 1)[1]
         return [model for model in models if tag in model["tags"]]
 
+    if condition.startswith("config"):
+        filtered_models = []
+        config_key, config_value = re.split(r'[.:]', condition)[1:]
+        for model in models:
+            if model.get("config", {}).get(config_key) == config_value:
+                filtered_models.append(model)
+        return filtered_models
+
     # simple match by name
     model_names = {model["name"]: model for model in models}
     if condition in model_names:

--- a/tests/cli/superset/sync/dbt/lib_test.py
+++ b/tests/cli/superset/sync/dbt/lib_test.py
@@ -391,7 +391,7 @@ def test_filter_models() -> None:
             "persist_docs": {},
             "quoting": {},
             "column_types": {},
-        }
+        },
     }
     models: List[ModelSchema] = [one, two, three]  # type: ignore
 
@@ -413,8 +413,9 @@ def test_filter_models() -> None:
     }
 
     # testing config filtering
-    assert {model["name"] for model in filter_models(models, "config.materialized:view")} == {"three"}
-
+    assert {
+        model["name"] for model in filter_models(models, "config.materialized:view")
+    } == {"three"}
 
     with pytest.raises(NotImplementedError) as excinfo:
         filter_models(models, "invalid")

--- a/tests/cli/superset/sync/dbt/lib_test.py
+++ b/tests/cli/superset/sync/dbt/lib_test.py
@@ -386,6 +386,12 @@ def test_filter_models() -> None:
         "unique_id": "model.three",
         "depends_on": ["source.zero"],
         "children": ["model.two"],
+        "config": {
+            "materialized": "view",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+        }
     }
     models: List[ModelSchema] = [one, two, three]  # type: ignore
 
@@ -405,6 +411,10 @@ def test_filter_models() -> None:
         "two",
         "three",
     }
+
+    # testing config filtering
+    assert {model["name"] for model in filter_models(models, "config.materialized:view")} == {"three"}
+
 
     with pytest.raises(NotImplementedError) as excinfo:
         filter_models(models, "invalid")


### PR DESCRIPTION
Users now will be able to filter `Model.config` values when running the cli
```
$ dbt run --select config.materialized:view

# w/ config
{{ config(
  materialized = 'view',
  unique_key = ['column_a', 'column_b'],
  grants = {'select': ['reporter', 'analysts']},
  transient = true
) }}
```