### PR TITLE
feat: sync certification information from dbt models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 0.2.2 - TBD
+==========================
+
+- Added the ability to sync ``certification`` and additional ``extra`` information from dbt models (`# <>`_).
+
 Version 0.2.1 - 2023-05-30
 ==========================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 Version 0.2.2 - TBD
 ==========================
 
-- Added the ability to sync ``certification`` and additional ``extra`` information from dbt models (`# <>`_).
+- Added the ability to sync ``certification`` and additional ``extra`` information from dbt models (`#213 <https://github.com/preset-io/backend-sdk/pull/213>`_).
 
 Version 0.2.1 - 2023-05-30
 ==========================

--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -83,11 +83,15 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
     # add datasets
     datasets = []
     for model in models:
-        
+
         # load additional metadata from dbt model definition
         model_kwargs = model.get("meta", {}).pop("superset", {})
-        certification = model_kwargs.get("extra", {}).pop("certification") if "certification" in model_kwargs else certification or {"details": "This table is produced by dbt"}
-        
+        certification = (
+            model_kwargs.get("extra", {}).pop("certification")
+            if "certification" in model_kwargs
+            else certification or {"details": "This table is produced by dbt"}
+        )
+
         filters = {
             "database": OneToMany(database["id"]),
             "schema": model["schema"],
@@ -112,7 +116,10 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
             "unique_id": model["unique_id"],
             "depends_on": "ref('{name}')".format(**model),
             "certification": certification,
-            **model_kwargs.pop("extra", {}) # include any additional or custom field specified in model.meta.superset.extra
+            **model_kwargs.pop(
+                "extra",
+                {},
+            ),  # include any additional or custom field specified in model.meta.superset.extra
         }
 
         dataset_metrics = []
@@ -133,7 +140,7 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
                     "verbose_name": metric.get("label", name),
                     "description": metric.get("description", ""),
                     "extra": json.dumps(meta),
-                    **kwargs, # include additional metric metadata defined in metric.meta.superset
+                    **kwargs,  # include additional metric metadata defined in metric.meta.superset
                 },
             )
 
@@ -143,7 +150,7 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
             "extra": json.dumps(extra),
             "is_managed_externally": disallow_edits,
             "metrics": [],
-            **model_kwargs, # include additional model metadata defined in model.meta.superset
+            **model_kwargs,  # include additional model metadata defined in model.meta.superset
         }
         if base_url:
             fragment = "!/model/{unique_id}".format(**model)

--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -83,6 +83,11 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
     # add datasets
     datasets = []
     for model in models:
+        
+        # load additional metadata from dbt model definition
+        model_kwargs = model.get("meta", {}).pop("superset", {})
+        certification = model_kwargs.get("extra", {}).pop("certification") if "certification" in model_kwargs else certification or {"details": "This table is produced by dbt"}
+        
         filters = {
             "database": OneToMany(database["id"]),
             "schema": model["schema"],
@@ -106,8 +111,8 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
         extra = {
             "unique_id": model["unique_id"],
             "depends_on": "ref('{name}')".format(**model),
-            "certification": certification
-            or {"details": "This table is produced by dbt"},
+            "certification": certification,
+            **model_kwargs.pop("extra", {}) # include any additional or custom field specified in model.meta.superset.extra
         }
 
         dataset_metrics = []
@@ -128,7 +133,7 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
                     "verbose_name": metric.get("label", name),
                     "description": metric.get("description", ""),
                     "extra": json.dumps(meta),
-                    **kwargs,
+                    **kwargs, # include additional metric metadata defined in metric.meta.superset
                 },
             )
 
@@ -138,8 +143,8 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
             "extra": json.dumps(extra),
             "is_managed_externally": disallow_edits,
             "metrics": [],
+            **model_kwargs, # include additional model metadata defined in model.meta.superset
         }
-        update.update(model.get("meta", {}).get("superset", {}))
         if base_url:
             fragment = "!/model/{unique_id}".format(**model)
             update["external_url"] = str(base_url.with_fragment(fragment))

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -1,7 +1,7 @@
 """
 Tests for ``preset_cli.cli.superset.sync.dbt.datasets``.
 """
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, too-many-lines
 
 import json
 from typing import List, cast
@@ -652,13 +652,7 @@ def test_sync_datasets_null_certification(mocker: MockerFixture) -> None:
                 "database": "examples_dev",
                 "schema": "public",
                 "description": "",
-                "meta": {
-                    "superset": {
-                        "extra": {
-                            "certification": None
-                        }
-                    }
-                },
+                "meta": {"superset": {"extra": {"certification": None}}},
                 "name": "messages_channels",
                 "unique_id": "model.superset_examples.messages_channels",
                 "columns": [{"name": "id", "description": "Primary key"}],
@@ -753,10 +747,10 @@ def test_sync_datasets_model_certification(mocker: MockerFixture) -> None:
                         "extra": {
                             "certification": {
                                 "details": "I declare this dataset certified",
-                                "certified_by": "Myself"
-                            }
-                        }
-                    }
+                                "certified_by": "Myself",
+                            },
+                        },
+                    },
                 },
                 "name": "messages_channels",
                 "unique_id": "model.superset_examples.messages_channels",
@@ -789,7 +783,7 @@ def test_sync_datasets_model_certification(mocker: MockerFixture) -> None:
                         "depends_on": "ref('messages_channels')",
                         "certification": {
                             "details": "I declare this dataset certified",
-                            "certified_by": "Myself"
+                            "certified_by": "Myself",
                         },
                     },
                 ),
@@ -851,11 +845,7 @@ def test_sync_datasets_warning(mocker: MockerFixture) -> None:
                 "schema": "public",
                 "description": "",
                 "meta": {
-                    "superset": {
-                        "extra": {
-                            "warning_markdown": "Under Construction"
-                        }
-                    }
+                    "superset": {"extra": {"warning_markdown": "Under Construction"}},
                 },
                 "name": "messages_channels",
                 "unique_id": "model.superset_examples.messages_channels",
@@ -947,11 +937,7 @@ def test_sync_datasets_meta_test(mocker: MockerFixture) -> None:
                 "database": "examples_dev",
                 "schema": "public",
                 "description": "",
-                "meta": {
-                    "superset": {
-                        "cache_timeout": 250
-                    }
-                },
+                "meta": {"superset": {"cache_timeout": 250}},
                 "name": "messages_channels",
                 "unique_id": "model.superset_examples.messages_channels",
                 "columns": [{"name": "id", "description": "Primary key"}],

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -630,3 +630,393 @@ def test_model_in_database() -> None:
     url = make_url("snowflake://user:password@host/db1")
     assert model_in_database(cast(ModelSchema, {"database": "db1"}), url)
     assert not model_in_database(cast(ModelSchema, {"database": "db2"}), url)
+
+
+def test_sync_datasets_null_certification(mocker: MockerFixture) -> None:
+    """
+    Test ``sync_datasets`` with no certification info
+    """
+    client = mocker.MagicMock()
+    client.get_datasets.return_value = []
+    client.create_dataset.side_effect = [{"id": 1}, {"id": 2}, {"id": 3}]
+    client.get_dataset.return_value = {
+        "columns": [
+            {"column_name": "id", "is_dttm": False, "type_generic": "INTEGER"},
+            {"column_name": "ts", "is_dttm": True, "type_generic": "TIMESTAMP"},
+        ],
+    }
+
+    models_with_null_certification: List[ModelSchema] = [
+        model_schema.load(
+            {
+                "database": "examples_dev",
+                "schema": "public",
+                "description": "",
+                "meta": {
+                    "superset": {
+                        "extra": {
+                            "certification": None
+                        }
+                    }
+                },
+                "name": "messages_channels",
+                "unique_id": "model.superset_examples.messages_channels",
+                "columns": [{"name": "id", "description": "Primary key"}],
+            },
+        ),
+    ]
+    sync_datasets(
+        client=client,
+        models=models_with_null_certification,
+        metrics=metrics,
+        database={"id": 1, "sqlalchemy_uri": "postgresql://user@host/examples_dev"},
+        disallow_edits=False,
+        external_url_prefix="",
+    )
+    client.create_dataset.assert_has_calls(
+        [
+            mock.call(database=1, schema="public", table_name="messages_channels"),
+        ],
+    )
+    client.update_dataset.assert_has_calls(
+        [
+            mock.call(
+                1,
+                override_columns=True,
+                description="",
+                extra=json.dumps(
+                    {
+                        "unique_id": "model.superset_examples.messages_channels",
+                        "depends_on": "ref('messages_channels')",
+                        "certification": None,
+                    },
+                ),
+                is_managed_externally=False,
+                metrics=[],
+            ),
+            mock.call(
+                1,
+                override_columns=False,
+                metrics=[
+                    {
+                        "expression": "COUNT(*)",
+                        "metric_name": "cnt",
+                        "metric_type": "count",
+                        "verbose_name": "",
+                        "description": "",
+                        "extra": "{}",
+                    },
+                ],
+            ),
+            mock.call(
+                1,
+                override_columns=True,
+                columns=[
+                    {
+                        "column_name": "id",
+                        "description": "Primary key",
+                        "is_dttm": False,
+                        "verbose_name": "id",
+                    },
+                    {
+                        "column_name": "ts",
+                        "is_dttm": True,
+                    },
+                ],
+            ),
+        ],
+    )
+
+
+def test_sync_datasets_model_certification(mocker: MockerFixture) -> None:
+    """
+    Test ``sync_datasets`` with certification from model definition
+    """
+    client = mocker.MagicMock()
+    client.get_datasets.return_value = []
+    client.create_dataset.side_effect = [{"id": 1}, {"id": 2}, {"id": 3}]
+    client.get_dataset.return_value = {
+        "columns": [
+            {"column_name": "id", "is_dttm": False, "type_generic": "INTEGER"},
+            {"column_name": "ts", "is_dttm": True, "type_generic": "TIMESTAMP"},
+        ],
+    }
+
+    models_with_model_certification: List[ModelSchema] = [
+        model_schema.load(
+            {
+                "database": "examples_dev",
+                "schema": "public",
+                "description": "",
+                "meta": {
+                    "superset": {
+                        "extra": {
+                            "certification": {
+                                "details": "I declare this dataset certified",
+                                "certified_by": "Myself"
+                            }
+                        }
+                    }
+                },
+                "name": "messages_channels",
+                "unique_id": "model.superset_examples.messages_channels",
+                "columns": [{"name": "id", "description": "Primary key"}],
+            },
+        ),
+    ]
+    sync_datasets(
+        client=client,
+        models=models_with_model_certification,
+        metrics=metrics,
+        database={"id": 1, "sqlalchemy_uri": "postgresql://user@host/examples_dev"},
+        disallow_edits=False,
+        external_url_prefix="",
+    )
+    client.create_dataset.assert_has_calls(
+        [
+            mock.call(database=1, schema="public", table_name="messages_channels"),
+        ],
+    )
+    client.update_dataset.assert_has_calls(
+        [
+            mock.call(
+                1,
+                override_columns=True,
+                description="",
+                extra=json.dumps(
+                    {
+                        "unique_id": "model.superset_examples.messages_channels",
+                        "depends_on": "ref('messages_channels')",
+                        "certification": {
+                            "details": "I declare this dataset certified",
+                            "certified_by": "Myself"
+                        },
+                    },
+                ),
+                is_managed_externally=False,
+                metrics=[],
+            ),
+            mock.call(
+                1,
+                override_columns=False,
+                metrics=[
+                    {
+                        "expression": "COUNT(*)",
+                        "metric_name": "cnt",
+                        "metric_type": "count",
+                        "verbose_name": "",
+                        "description": "",
+                        "extra": "{}",
+                    },
+                ],
+            ),
+            mock.call(
+                1,
+                override_columns=True,
+                columns=[
+                    {
+                        "column_name": "id",
+                        "description": "Primary key",
+                        "is_dttm": False,
+                        "verbose_name": "id",
+                    },
+                    {
+                        "column_name": "ts",
+                        "is_dttm": True,
+                    },
+                ],
+            ),
+        ],
+    )
+
+
+def test_sync_datasets_warning(mocker: MockerFixture) -> None:
+    """
+    Test ``sync_datasets`` with warning information
+    """
+    client = mocker.MagicMock()
+    client.get_datasets.return_value = []
+    client.create_dataset.side_effect = [{"id": 1}, {"id": 2}, {"id": 3}]
+    client.get_dataset.return_value = {
+        "columns": [
+            {"column_name": "id", "is_dttm": False, "type_generic": "INTEGER"},
+            {"column_name": "ts", "is_dttm": True, "type_generic": "TIMESTAMP"},
+        ],
+    }
+
+    models_with_warning: List[ModelSchema] = [
+        model_schema.load(
+            {
+                "database": "examples_dev",
+                "schema": "public",
+                "description": "",
+                "meta": {
+                    "superset": {
+                        "extra": {
+                            "warning_markdown": "Under Construction"
+                        }
+                    }
+                },
+                "name": "messages_channels",
+                "unique_id": "model.superset_examples.messages_channels",
+                "columns": [{"name": "id", "description": "Primary key"}],
+            },
+        ),
+    ]
+    sync_datasets(
+        client=client,
+        models=models_with_warning,
+        metrics=metrics,
+        database={"id": 1, "sqlalchemy_uri": "postgresql://user@host/examples_dev"},
+        disallow_edits=False,
+        external_url_prefix="",
+    )
+    client.create_dataset.assert_has_calls(
+        [
+            mock.call(database=1, schema="public", table_name="messages_channels"),
+        ],
+    )
+    client.update_dataset.assert_has_calls(
+        [
+            mock.call(
+                1,
+                override_columns=True,
+                description="",
+                extra=json.dumps(
+                    {
+                        "unique_id": "model.superset_examples.messages_channels",
+                        "depends_on": "ref('messages_channels')",
+                        "certification": {"details": "This table is produced by dbt"},
+                        "warning_markdown": "Under Construction",
+                    },
+                ),
+                is_managed_externally=False,
+                metrics=[],
+            ),
+            mock.call(
+                1,
+                override_columns=False,
+                metrics=[
+                    {
+                        "expression": "COUNT(*)",
+                        "metric_name": "cnt",
+                        "metric_type": "count",
+                        "verbose_name": "",
+                        "description": "",
+                        "extra": "{}",
+                    },
+                ],
+            ),
+            mock.call(
+                1,
+                override_columns=True,
+                columns=[
+                    {
+                        "column_name": "id",
+                        "description": "Primary key",
+                        "is_dttm": False,
+                        "verbose_name": "id",
+                    },
+                    {
+                        "column_name": "ts",
+                        "is_dttm": True,
+                    },
+                ],
+            ),
+        ],
+    )
+
+
+def test_sync_datasets_meta_test(mocker: MockerFixture) -> None:
+    """
+    Test ``sync_datasets`` with an additional field set through meta.superset
+    """
+    client = mocker.MagicMock()
+    client.get_datasets.return_value = []
+    client.create_dataset.side_effect = [{"id": 1}, {"id": 2}, {"id": 3}]
+    client.get_dataset.return_value = {
+        "columns": [
+            {"column_name": "id", "is_dttm": False, "type_generic": "INTEGER"},
+            {"column_name": "ts", "is_dttm": True, "type_generic": "TIMESTAMP"},
+        ],
+    }
+
+    models_with_meta_info: List[ModelSchema] = [
+        model_schema.load(
+            {
+                "database": "examples_dev",
+                "schema": "public",
+                "description": "",
+                "meta": {
+                    "superset": {
+                        "cache_timeout": 250
+                    }
+                },
+                "name": "messages_channels",
+                "unique_id": "model.superset_examples.messages_channels",
+                "columns": [{"name": "id", "description": "Primary key"}],
+            },
+        ),
+    ]
+    sync_datasets(
+        client=client,
+        models=models_with_meta_info,
+        metrics=metrics,
+        database={"id": 1, "sqlalchemy_uri": "postgresql://user@host/examples_dev"},
+        disallow_edits=False,
+        external_url_prefix="",
+    )
+    client.create_dataset.assert_has_calls(
+        [
+            mock.call(database=1, schema="public", table_name="messages_channels"),
+        ],
+    )
+    client.update_dataset.assert_has_calls(
+        [
+            mock.call(
+                1,
+                override_columns=True,
+                description="",
+                extra=json.dumps(
+                    {
+                        "unique_id": "model.superset_examples.messages_channels",
+                        "depends_on": "ref('messages_channels')",
+                        "certification": {"details": "This table is produced by dbt"},
+                    },
+                ),
+                is_managed_externally=False,
+                metrics=[],
+                cache_timeout=250,
+            ),
+            mock.call(
+                1,
+                override_columns=False,
+                metrics=[
+                    {
+                        "expression": "COUNT(*)",
+                        "metric_name": "cnt",
+                        "metric_type": "count",
+                        "verbose_name": "",
+                        "description": "",
+                        "extra": "{}",
+                    },
+                ],
+            ),
+            mock.call(
+                1,
+                override_columns=True,
+                columns=[
+                    {
+                        "column_name": "id",
+                        "description": "Primary key",
+                        "is_dttm": False,
+                        "verbose_name": "id",
+                    },
+                    {
+                        "column_name": "ts",
+                        "is_dttm": True,
+                    },
+                ],
+            ),
+        ],
+    )


### PR DESCRIPTION
This PR introduces the ability to control `certification` information from the dbt models definition. Previously, the certification would be automatically set to:
``` json
{
    "certification":
    {
        "details": "This table is produced by dbt"
    }
```

Now, the `certification` can be defined on the `meta.superset.extra.certification` field. For example:

``` yaml
models:
  - name: dbt_vehicle_sales
    meta:
      superset:
        extra:
          certification: 
            certified_by: Data Analytics team
            details: Vehicle Sales data
```

It's also possible to set `certification` to `null`, to prevent displaying the pop up in the Superset UI (useful in case the model is not ready yet for Production use):

``` yaml
models:
  - name: dbt_vehicle_sales
    meta:
      superset:
        extra:
          certification: null
```

Additional fields can also be specified for the `extra` field, such as the `warning_markdown`:

``` yaml
models:
  - name: dbt_vehicle_sales
    meta:
      superset:
        extra:
          warning_markdown: UNDER CONSTRUCTION
```

Added some new test scenarios for the dataset sync.