### PR TITLE
fix: Removing the certification key in case certification is null

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -86,11 +86,13 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
 
         # load additional metadata from dbt model definition
         model_kwargs = model.get("meta", {}).pop("superset", {})
-        certification = (
-            model_kwargs.get("extra", {}).pop("certification")
-            if "certification" in model_kwargs
-            else certification or {"details": "This table is produced by dbt"}
-        )
+        certification_info = {
+            "certification": (
+                model_kwargs.get("extra", {}).pop("certification")
+                if "certification" in model_kwargs.get("extra", {})
+                else certification or {"details": "This table is produced by dbt"}
+            ),
+        }
 
         filters = {
             "database": OneToMany(database["id"]),
@@ -115,7 +117,11 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
         extra = {
             "unique_id": model["unique_id"],
             "depends_on": "ref('{name}')".format(**model),
-            "certification": certification,
+            **(
+                certification_info
+                if certification_info["certification"] is not None
+                else {}
+            ),
             **model_kwargs.pop(
                 "extra",
                 {},

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -682,7 +682,6 @@ def test_sync_datasets_null_certification(mocker: MockerFixture) -> None:
                     {
                         "unique_id": "model.superset_examples.messages_channels",
                         "depends_on": "ref('messages_channels')",
-                        "certification": None,
                     },
                 ),
                 is_managed_externally=False,


### PR DESCRIPTION
This PR adds a few fixes/improvements to the dataset certification flow:
* In case the `certification` is set to `null` via the dbt model definition, before we were setting `certification: null` in the dataset, which wouldn't show the certification pop up, but it would still include the dataset when filtering for `certified: yes`. With these changes, in case `certification` is set to `null` in the model definition, the `certification` key won't be included in the dataset's `extra` field.
* Renamed the `certification` local variable to `certification_info` to better distinguish from the function argument. Also changed its content to a dictionary to only include the key pair in the `extra` definition in case it contains an actual value.
* Updated the test for the new desired flow. 