### PR TITLE
(fix)Exposures definitions and added ability to preserve columns

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -67,6 +67,12 @@ from preset_cli.exceptions import DatabaseNotFoundError
     default=False,
     help="Do not sync models to datasets and only fetch exposures instead",
 )
+@click.option(
+    "--preserve-columns",
+    is_flag=True,
+    default=False,
+    help="Preserve column configurations",
+)
 @click.pass_context
 def dbt_core(  # pylint: disable=too-many-arguments, too-many-locals
     ctx: click.core.Context,
@@ -81,6 +87,7 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-locals
     disallow_edits: bool = True,
     external_url_prefix: str = "",
     exposures_only: bool = False,
+    preserve_columns: bool = False,
 ) -> None:
     """
     Sync models/metrics from dbt Core to Superset and charts/dashboards to dbt exposures.
@@ -88,6 +95,8 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-locals
     auth = ctx.obj["AUTH"]
     url = URL(ctx.obj["INSTANCE"])
     client = SupersetClient(url, auth)
+
+    reload_columns = not preserve_columns
 
     if profiles is None:
         profiles = os.path.expanduser("~/.dbt/profiles.yml")
@@ -134,7 +143,7 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-locals
             models.append(model_schema.load(config))
     models = apply_select(models, select, exclude)
     model_map = {
-        ModelKey(model["schema"], model["name"]): f'ref({model["name"]})'
+        ModelKey(model["schema"], model["name"]): f'ref(\'{model["name"]}\')'
         for model in models
     }
 
@@ -175,6 +184,7 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-locals
             database,
             disallow_edits,
             external_url_prefix,
+            reload_columns=reload_columns,
         )
 
     if exposures:
@@ -300,6 +310,12 @@ def get_job_id(
     default=False,
     help="Do not sync models to datasets and only fetch exposures instead",
 )
+@click.option(
+    "--preserve-columns",
+    is_flag=True,
+    default=False,
+    help="Preserve column configurations",
+)
 @click.pass_context
 def dbt_cloud(  # pylint: disable=too-many-arguments, too-many-locals
     ctx: click.core.Context,
@@ -311,6 +327,7 @@ def dbt_cloud(  # pylint: disable=too-many-arguments, too-many-locals
     disallow_edits: bool = True,
     external_url_prefix: str = "",
     exposures_only: bool = False,
+    preserve_columns: bool = False,
 ) -> None:
     """
     Sync models/metrics from dbt Cloud to Superset.
@@ -321,6 +338,8 @@ def dbt_cloud(  # pylint: disable=too-many-arguments, too-many-locals
 
     dbt_auth = TokenAuth(token)
     dbt_client = DBTClient(dbt_auth)
+
+    reload_columns = not preserve_columns
 
     if job_id is None:
         job_id = get_job_id(dbt_client)
@@ -340,7 +359,7 @@ def dbt_cloud(  # pylint: disable=too-many-arguments, too-many-locals
     models = dbt_client.get_models(job_id)
     models = apply_select(models, select, exclude)
     model_map = {
-        ModelKey(model["schema"], model["name"]): f'ref({model["name"]})'
+        ModelKey(model["schema"], model["name"]): f'ref(\'{model["name"]}\')'
         for model in models
     }
     metrics = dbt_client.get_metrics(job_id)
@@ -359,6 +378,7 @@ def dbt_cloud(  # pylint: disable=too-many-arguments, too-many-locals
             database,
             disallow_edits,
             external_url_prefix,
+            reload_columns=reload_columns,
         )
 
     if exposures:

--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -359,7 +359,7 @@ def dbt_cloud(  # pylint: disable=too-many-arguments, too-many-locals
     models = dbt_client.get_models(job_id)
     models = apply_select(models, select, exclude)
     model_map = {
-        ModelKey(model["schema"], model["name"]): f'ref(\'{model["name"]}\')'
+        ModelKey(model["schema"], model["name"]): f"ref('{model['name']}')"
         for model in models
     }
     metrics = dbt_client.get_metrics(job_id)

--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -143,7 +143,7 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-locals
             models.append(model_schema.load(config))
     models = apply_select(models, select, exclude)
     model_map = {
-        ModelKey(model["schema"], model["name"]): f'ref(\'{model["name"]}\')'
+        ModelKey(model["schema"], model["name"]): f"ref('{model['name']}')"
         for model in models
     }
 

--- a/src/preset_cli/cli/superset/sync/dbt/exposures.py
+++ b/src/preset_cli/cli/superset/sync/dbt/exposures.py
@@ -147,16 +147,8 @@ def sync_exposures(  # pylint: disable=too-many-locals
         dashboard = client.get_dashboard(dashboard_id)
         first_owner = dashboard["owners"][0]
 
-        asset_title = re.sub(
-            r"[^a-zA-Z0-9 _]",
-            "",
-            dashboard["dashboard_title"],
-        )  # remove unsupported characters
-        asset_title = re.sub(
-            r" ",
-            "_",
-            asset_title,
-        )  # replace blank spaces with underscores
+        asset_title = re.sub(" ", "_", dashboard["dashboard_title"])
+        asset_title = re.sub("\W", "", asset_title)
 
         exposure = {
             "name": asset_title + "_dashboard_" + str(dashboard_id),

--- a/src/preset_cli/cli/superset/sync/dbt/exposures.py
+++ b/src/preset_cli/cli/superset/sync/dbt/exposures.py
@@ -121,16 +121,8 @@ def sync_exposures(  # pylint: disable=too-many-locals
         chart = client.get_chart(chart_id)
         first_owner = chart["owners"][0]
 
-        asset_title = re.sub(
-            r"[^a-zA-Z0-9 _]",
-            "",
-            chart["slice_name"],
-        )  # remove unsupported characters
-        asset_title = re.sub(
-            r" ",
-            "_",
-            asset_title,
-        )  # replace blank spaces with underscores
+        asset_title = re.sub(" ", "_", chart["slice_name"])
+        asset_title = re.sub("\W", "", asset_title)
 
         exposure = {
             "name": asset_title + "_chart_" + str(chart_id),

--- a/src/preset_cli/cli/superset/sync/dbt/exposures.py
+++ b/src/preset_cli/cli/superset/sync/dbt/exposures.py
@@ -121,7 +121,7 @@ def sync_exposures(  # pylint: disable=too-many-locals
         chart = client.get_chart(chart_id)
         first_owner = chart["owners"][0]
 
-        # remove unsupported characters for dbt exposure name
+        # remove unsupported characters for dbt exposures name
         asset_title = re.sub(" ", "_", chart["slice_name"])
         asset_title = re.sub(r"\W", "", asset_title)
 

--- a/src/preset_cli/cli/superset/sync/dbt/exposures.py
+++ b/src/preset_cli/cli/superset/sync/dbt/exposures.py
@@ -121,6 +121,7 @@ def sync_exposures(  # pylint: disable=too-many-locals
         chart = client.get_chart(chart_id)
         first_owner = chart["owners"][0]
 
+        # remove unsupported characters for dbt exposure name
         asset_title = re.sub(" ", "_", chart["slice_name"])
         asset_title = re.sub(r"\W", "", asset_title)
 

--- a/src/preset_cli/cli/superset/sync/dbt/exposures.py
+++ b/src/preset_cli/cli/superset/sync/dbt/exposures.py
@@ -3,6 +3,7 @@ Sync Superset dashboards as dbt exposures.
 """
 
 import json
+import re
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional
 
@@ -31,8 +32,17 @@ def get_chart_depends_on(
     Get all the dbt dependencies for a given chart.
     """
 
-    query_context = json.loads(chart["query_context"])
-    dataset_id = query_context["datasource"]["id"]
+    # imported charts have a null query context until loaded in Explore for the first time.
+    # in that case, we can get the dataset id from the params
+    if chart["query_context"]:
+        dataset_id = json.loads(chart["query_context"])["datasource"]["id"]
+    elif chart["params"]:
+        dataset_id = json.loads(chart["params"])["datasource"].split("__")[0]
+    else:
+        raise Exception(
+            f'Unable to find dataset information for Chart {chart["slice_name"]}',
+        )
+
     dataset = client.get_dataset(dataset_id)
     extra = json.loads(dataset["extra"] or "{}")
     if "depends_on" in extra:
@@ -110,8 +120,21 @@ def sync_exposures(  # pylint: disable=too-many-locals
     for chart_id in charts_ids:
         chart = client.get_chart(chart_id)
         first_owner = chart["owners"][0]
+
+        asset_title = re.sub(
+            r"[^a-zA-Z0-9 _]",
+            "",
+            chart["slice_name"],
+        )  # remove unsupported characters
+        asset_title = re.sub(
+            r" ",
+            "_",
+            asset_title,
+        )  # replace blank spaces with underscores
+
         exposure = {
-            "name": chart["slice_name"] + " [chart]",
+            "name": asset_title + "_chart_" + str(chart_id),
+            "label": chart["slice_name"] + " [chart]",
             "type": "analysis",
             "maturity": "high" if chart["certified_by"] else "low",
             "url": str(
@@ -131,8 +154,21 @@ def sync_exposures(  # pylint: disable=too-many-locals
     for dashboard_id in dashboards_ids:
         dashboard = client.get_dashboard(dashboard_id)
         first_owner = dashboard["owners"][0]
+
+        asset_title = re.sub(
+            r"[^a-zA-Z0-9 _]",
+            "",
+            dashboard["dashboard_title"],
+        )  # remove unsupported characters
+        asset_title = re.sub(
+            r" ",
+            "_",
+            asset_title,
+        )  # replace blank spaces with underscores
+
         exposure = {
-            "name": dashboard["dashboard_title"] + " [dashboard]",
+            "name": asset_title + "_dashboard_" + str(dashboard_id),
+            "label": dashboard["dashboard_title"] + " [dashboard]",
             "type": "dashboard",
             "maturity": "high"
             if dashboard["published"] or dashboard["certified_by"]

--- a/src/preset_cli/cli/superset/sync/dbt/exposures.py
+++ b/src/preset_cli/cli/superset/sync/dbt/exposures.py
@@ -122,7 +122,7 @@ def sync_exposures(  # pylint: disable=too-many-locals
         first_owner = chart["owners"][0]
 
         asset_title = re.sub(" ", "_", chart["slice_name"])
-        asset_title = re.sub("\W", "", asset_title)
+        asset_title = re.sub(r"\W", "", asset_title)
 
         exposure = {
             "name": asset_title + "_chart_" + str(chart_id),
@@ -148,7 +148,7 @@ def sync_exposures(  # pylint: disable=too-many-locals
         first_owner = dashboard["owners"][0]
 
         asset_title = re.sub(" ", "_", dashboard["dashboard_title"])
-        asset_title = re.sub("\W", "", asset_title)
+        asset_title = re.sub(r"\W", "", asset_title)
 
         exposure = {
             "name": asset_title + "_dashboard_" + str(dashboard_id),

--- a/tests/cli/superset/sync/dbt/command_test.py
+++ b/tests/cli/superset/sync/dbt/command_test.py
@@ -24,6 +24,132 @@ dirname, _ = os.path.split(os.path.abspath(__file__))
 with open(os.path.join(dirname, "manifest.json"), encoding="utf-8") as fp:
     manifest_contents = fp.read()
 
+dbt_core_models = [
+    {
+        "database": "examples_dev",
+        "columns": [],
+        "meta": {},
+        "description": "",
+        "name": "messages_channels",
+        "tags": [],
+        "schema": "public",
+        "unique_id": "model.superset_examples.messages_channels",
+        "created_at": 1642628933.004452,
+        "children": ["metric.superset_examples.cnt"],
+        "depends_on": {
+            "macros": [],
+            "nodes": [
+                "source.superset_examples.public.channels",
+                "source.superset_examples.public.messages",
+            ],
+        },
+        "unrendered_config": {"materialized": "view"},
+        "resource_type": "model",
+        "path": "slack/messages_channels.sql",
+        "extra_ctes": [],
+        "package_name": "superset_examples",
+        "alias": "messages_channels",
+        "relation_name": '"examples_dev"."public"."messages_channels"',
+        "config": {
+            "enabled": True,
+            "alias": None,
+            "schema": None,
+            "database": None,
+            "tags": [],
+            "meta": {},
+            "materialized": "view",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "full_refresh": None,
+            "on_schema_change": "ignore",
+            "post-hook": [],
+            "pre-hook": [],
+        },
+        "patch_path": None,
+        "compiled_sql": (
+            "SELECT messages.ts, channels.name, messages.text "
+            'FROM "examples_dev"."public"."messages" messages '
+            'JOIN "examples_dev"."public"."channels" channels '
+            "ON messages.channel_id = channels.id"
+        ),
+        "extra_ctes_injected": True,
+        "deferred": False,
+        "root_path": "/Users/beto/Projects/dbt-examples/superset_examples",
+        "original_file_path": "models/slack/messages_channels.sql",
+        "refs": [],
+        "fqn": ["superset_examples", "slack", "messages_channels"],
+        "raw_sql": (
+            "SELECT messages.ts, channels.name, messages.text "
+            "FROM {{ source ('public', 'messages') }} messages "
+            "JOIN {{ source ('public', 'channels') }} channels "
+            "ON messages.channel_id = channels.id"
+        ),
+        "build_path": None,
+        "sources": [["public", "channels"], ["public", "messages"]],
+        "checksum": {
+            "name": "sha256",
+            "checksum": "b4ce232b28280daa522b37e12c36b67911e2a98456b8a3b99440075ec5564609",
+        },
+        "docs": {"show": True},
+        "compiled_path": "target/compiled/superset_examples/models/slack/messages_channels.sql",
+        "compiled": True,
+    },
+]
+
+dbt_core_metrics = [
+    {
+        "label": "",
+        "sql": "*",
+        "depends_on": ["model.superset_examples.messages_channels"],
+        "meta": {},
+        "description": "",
+        "name": "cnt",
+        "type": "count",
+        "filters": [],
+        "unique_id": "metric.superset_examples.cnt",
+        "created_at": 1642630986.1942852,
+        "package_name": "superset_examples",
+        "sources": [],
+        "root_path": "/Users/beto/Projects/dbt-examples/superset_examples",
+        "path": "slack/schema.yml",
+        "resource_type": "metric",
+        "original_file_path": "models/slack/schema.yml",
+        "model": "ref('messages_channels')",
+        "timestamp": None,
+        "fqn": ["superset_examples", "slack", "cnt"],
+        "time_grains": [],
+        "tags": [],
+        "refs": [["messages_channels"]],
+        "dimensions": [],
+    },
+]
+
+dbt_cloud_models = [
+    {
+        "database": "examples_dev",
+        "description": "",
+        "meta": {},
+        "name": "messages_channels",
+        "schema": "public",
+        "unique_id": "model.superset_examples.messages_channels",
+    },
+]
+
+dbt_cloud_metrics = [
+    {
+        "depends_on": ["model.superset_examples.messages_channels"],
+        "description": "",
+        "filters": [],
+        "label": "",
+        "meta": {},
+        "name": "cnt",
+        "sql": "*",
+        "type": "count",
+        "unique_id": "metric.superset_examples.cnt",
+    },
+]
+
 
 def test_dbt_core(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     """
@@ -79,118 +205,97 @@ def test_dbt_core(mocker: MockerFixture, fs: FakeFilesystem) -> None:
         False,
         "",
     )
-    models = [
-        {
-            "database": "examples_dev",
-            "columns": [],
-            "meta": {},
-            "description": "",
-            "name": "messages_channels",
-            "tags": [],
-            "schema": "public",
-            "unique_id": "model.superset_examples.messages_channels",
-            "created_at": 1642628933.004452,
-            "children": ["metric.superset_examples.cnt"],
-            "depends_on": {
-                "macros": [],
-                "nodes": [
-                    "source.superset_examples.public.channels",
-                    "source.superset_examples.public.messages",
-                ],
-            },
-            "unrendered_config": {"materialized": "view"},
-            "resource_type": "model",
-            "path": "slack/messages_channels.sql",
-            "extra_ctes": [],
-            "package_name": "superset_examples",
-            "alias": "messages_channels",
-            "relation_name": '"examples_dev"."public"."messages_channels"',
-            "config": {
-                "enabled": True,
-                "alias": None,
-                "schema": None,
-                "database": None,
-                "tags": [],
-                "meta": {},
-                "materialized": "view",
-                "persist_docs": {},
-                "quoting": {},
-                "column_types": {},
-                "full_refresh": None,
-                "on_schema_change": "ignore",
-                "post-hook": [],
-                "pre-hook": [],
-            },
-            "patch_path": None,
-            "compiled_sql": (
-                "SELECT messages.ts, channels.name, messages.text "
-                'FROM "examples_dev"."public"."messages" messages '
-                'JOIN "examples_dev"."public"."channels" channels '
-                "ON messages.channel_id = channels.id"
-            ),
-            "extra_ctes_injected": True,
-            "deferred": False,
-            "root_path": "/Users/beto/Projects/dbt-examples/superset_examples",
-            "original_file_path": "models/slack/messages_channels.sql",
-            "refs": [],
-            "fqn": ["superset_examples", "slack", "messages_channels"],
-            "raw_sql": (
-                "SELECT messages.ts, channels.name, messages.text "
-                "FROM {{ source ('public', 'messages') }} messages "
-                "JOIN {{ source ('public', 'channels') }} channels "
-                "ON messages.channel_id = channels.id"
-            ),
-            "build_path": None,
-            "sources": [["public", "channels"], ["public", "messages"]],
-            "checksum": {
-                "name": "sha256",
-                "checksum": "b4ce232b28280daa522b37e12c36b67911e2a98456b8a3b99440075ec5564609",
-            },
-            "docs": {"show": True},
-            "compiled_path": "target/compiled/superset_examples/models/slack/messages_channels.sql",
-            "compiled": True,
-        },
-    ]
-    metrics = [
-        {
-            "label": "",
-            "sql": "*",
-            "depends_on": ["model.superset_examples.messages_channels"],
-            "meta": {},
-            "description": "",
-            "name": "cnt",
-            "type": "count",
-            "filters": [],
-            "unique_id": "metric.superset_examples.cnt",
-            "created_at": 1642630986.1942852,
-            "package_name": "superset_examples",
-            "sources": [],
-            "root_path": "/Users/beto/Projects/dbt-examples/superset_examples",
-            "path": "slack/schema.yml",
-            "resource_type": "metric",
-            "original_file_path": "models/slack/schema.yml",
-            "model": "ref('messages_channels')",
-            "timestamp": None,
-            "fqn": ["superset_examples", "slack", "cnt"],
-            "time_grains": [],
-            "tags": [],
-            "refs": [["messages_channels"]],
-            "dimensions": [],
-        },
-    ]
+
     sync_datasets.assert_called_with(
         client,
-        models,
-        metrics,
+        dbt_core_models,
+        dbt_core_metrics,
         sync_database(),
         False,
         "",
+        reload_columns=True,
     )
     sync_exposures.assert_called_with(
         client,
         exposures,
         sync_datasets(),
-        {("public", "messages_channels"): "ref(messages_channels)"},
+        {("public", "messages_channels"): "ref('messages_channels')"},
+    )
+
+
+def test_dbt_core_reload_columns_false(
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
+) -> None:
+    """
+    Test the ``dbt-core`` command with --preserve-columns flag
+    """
+    root = Path("/path/to/root")
+    fs.create_dir(root)
+    manifest = root / "default/target/manifest.json"
+    fs.create_file(manifest, contents=manifest_contents)
+    profiles = root / ".dbt/profiles.yml"
+    fs.create_file(profiles)
+    exposures = root / "models/exposures.yml"
+    fs.create_file(exposures)
+
+    SupersetClient = mocker.patch(
+        "preset_cli.cli.superset.sync.dbt.command.SupersetClient",
+    )
+    client = SupersetClient()
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+    sync_database = mocker.patch(
+        "preset_cli.cli.superset.sync.dbt.command.sync_database",
+    )
+    sync_datasets = mocker.patch(
+        "preset_cli.cli.superset.sync.dbt.command.sync_datasets",
+    )
+    sync_exposures = mocker.patch(
+        "preset_cli.cli.superset.sync.dbt.command.sync_exposures",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        superset_cli,
+        [
+            "https://superset.example.org/",
+            "sync",
+            "dbt-core",
+            str(manifest),
+            "--profiles",
+            str(profiles),
+            "--exposures",
+            str(exposures),
+            "--preserve-columns",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    sync_database.assert_called_with(
+        client,
+        profiles,
+        "default",
+        "default",
+        None,
+        False,
+        False,
+        "",
+    )
+
+    sync_datasets.assert_called_with(
+        client,
+        dbt_core_models,
+        dbt_core_metrics,
+        sync_database(),
+        False,
+        "",
+        reload_columns=False,
+    )
+    sync_exposures.assert_called_with(
+        client,
+        exposures,
+        sync_datasets(),
+        {("public", "messages_channels"): "ref('messages_channels')"},
     )
 
 
@@ -443,12 +548,13 @@ def test_dbt(mocker: MockerFixture, fs: FakeFilesystem) -> None:
         sync_database(),
         False,
         "",
+        reload_columns=True,
     )
     sync_exposures.assert_called_with(
         client,
         exposures,
         sync_datasets(),
-        {("public", "messages_channels"): "ref(messages_channels)"},
+        {("public", "messages_channels"): "ref('messages_channels')"},
     )
 
 
@@ -596,31 +702,9 @@ def test_dbt_cloud(mocker: MockerFixture) -> None:
     sync_datasets = mocker.patch(
         "preset_cli.cli.superset.sync.dbt.command.sync_datasets",
     )
-    models = [
-        {
-            "database": "examples_dev",
-            "description": "",
-            "meta": {},
-            "name": "messages_channels",
-            "schema": "public",
-            "unique_id": "model.superset_examples.messages_channels",
-        },
-    ]
-    dbt_client.get_models.return_value = models
-    metrics = [
-        {
-            "depends_on": ["model.superset_examples.messages_channels"],
-            "description": "",
-            "filters": [],
-            "label": "",
-            "meta": {},
-            "name": "cnt",
-            "sql": "*",
-            "type": "count",
-            "unique_id": "metric.superset_examples.cnt",
-        },
-    ]
-    dbt_client.get_metrics.return_value = metrics
+
+    dbt_client.get_models.return_value = dbt_cloud_models
+    dbt_client.get_metrics.return_value = dbt_cloud_metrics
     database = mocker.MagicMock()
     superset_client.get_databases.return_value = [database]
     superset_client.get_database.return_value = database
@@ -640,11 +724,60 @@ def test_dbt_cloud(mocker: MockerFixture) -> None:
     assert result.exit_code == 0
     sync_datasets.assert_called_with(
         superset_client,
-        models,
-        metrics,
+        dbt_cloud_models,
+        dbt_cloud_metrics,
         database,
         False,
         "",
+        reload_columns=True,
+    )
+
+
+def test_dbt_cloud_reload_columns_false(mocker: MockerFixture) -> None:
+    """
+    Test the ``dbt-cloud`` command with the --preserve-columns flag.
+    """
+    SupersetClient = mocker.patch(
+        "preset_cli.cli.superset.sync.dbt.command.SupersetClient",
+    )
+    superset_client = SupersetClient()
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+    DBTClient = mocker.patch(
+        "preset_cli.cli.superset.sync.dbt.command.DBTClient",
+    )
+    dbt_client = DBTClient()
+    sync_datasets = mocker.patch(
+        "preset_cli.cli.superset.sync.dbt.command.sync_datasets",
+    )
+
+    dbt_client.get_models.return_value = dbt_cloud_models
+    dbt_client.get_metrics.return_value = dbt_cloud_metrics
+    database = mocker.MagicMock()
+    superset_client.get_databases.return_value = [database]
+    superset_client.get_database.return_value = database
+
+    runner = CliRunner()
+    result = runner.invoke(
+        superset_cli,
+        [
+            "https://superset.example.org/",
+            "sync",
+            "dbt-cloud",
+            "XXX",
+            "123",
+            "--preserve-columns",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    sync_datasets.assert_called_with(
+        superset_client,
+        dbt_cloud_models,
+        dbt_cloud_metrics,
+        database,
+        False,
+        "",
+        reload_columns=False,
     )
 
 
@@ -664,31 +797,9 @@ def test_dbt_cloud_no_job_id(mocker: MockerFixture) -> None:
     sync_datasets = mocker.patch(
         "preset_cli.cli.superset.sync.dbt.command.sync_datasets",
     )
-    models = [
-        {
-            "database": "examples_dev",
-            "description": "",
-            "meta": {},
-            "name": "messages_channels",
-            "schema": "public",
-            "unique_id": "model.superset_examples.messages_channels",
-        },
-    ]
-    dbt_client.get_models.return_value = models
-    metrics = [
-        {
-            "depends_on": ["model.superset_examples.messages_channels"],
-            "description": "",
-            "filters": [],
-            "label": "",
-            "meta": {},
-            "name": "cnt",
-            "sql": "*",
-            "type": "count",
-            "unique_id": "metric.superset_examples.cnt",
-        },
-    ]
-    dbt_client.get_metrics.return_value = metrics
+
+    dbt_client.get_models.return_value = dbt_cloud_models
+    dbt_client.get_metrics.return_value = dbt_cloud_metrics
     dbt_client.get_accounts.return_value = [{"id": 1, "name": "My account"}]
     dbt_client.get_projects.return_value = [{"id": 1000, "name": "My project"}]
     dbt_client.get_jobs.return_value = [{"id": 123, "name": "My job"}]
@@ -713,11 +824,12 @@ def test_dbt_cloud_no_job_id(mocker: MockerFixture) -> None:
     dbt_client.get_metrics.assert_called_with(123)
     sync_datasets.assert_called_with(
         superset_client,
-        models,
-        metrics,
+        dbt_cloud_models,
+        dbt_cloud_metrics,
         database,
         False,
         "",
+        reload_columns=True,
     )
 
 
@@ -952,7 +1064,7 @@ def test_dbt_core_exposures_only(mocker: MockerFixture, fs: FakeFilesystem) -> N
         [
             {"schema": "public", "table_name": "messages_channels"},
         ],
-        {("public", "messages_channels"): "ref(messages_channels)"},
+        {("public", "messages_channels"): "ref('messages_channels')"},
     )
 
 
@@ -984,31 +1096,9 @@ def test_dbt_cloud_exposures_only(mocker: MockerFixture, fs: FakeFilesystem) -> 
     sync_exposures = mocker.patch(
         "preset_cli.cli.superset.sync.dbt.command.sync_exposures",
     )
-    models = [
-        {
-            "database": "examples_dev",
-            "description": "",
-            "meta": {},
-            "name": "messages_channels",
-            "schema": "public",
-            "unique_id": "model.superset_examples.messages_channels",
-        },
-    ]
-    dbt_client.get_models.return_value = models
-    metrics = [
-        {
-            "depends_on": ["model.superset_examples.messages_channels"],
-            "description": "",
-            "filters": [],
-            "label": "",
-            "meta": {},
-            "name": "cnt",
-            "sql": "*",
-            "type": "count",
-            "unique_id": "metric.superset_examples.cnt",
-        },
-    ]
-    dbt_client.get_metrics.return_value = metrics
+
+    dbt_client.get_models.return_value = dbt_cloud_models
+    dbt_client.get_metrics.return_value = dbt_cloud_metrics
     database = mocker.MagicMock()
     superset_client.get_databases.return_value = [database]
     superset_client.get_database.return_value = database
@@ -1036,5 +1126,5 @@ def test_dbt_cloud_exposures_only(mocker: MockerFixture, fs: FakeFilesystem) -> 
         [
             {"schema": "public", "table_name": "messages_channels"},
         ],
-        {("public", "messages_channels"): "ref(messages_channels)"},
+        {("public", "messages_channels"): "ref('messages_channels')"},
     )


### PR DESCRIPTION
This PR addresses a few issues with the exposures sync:
* In the past, we were not including the single quotes to specify the model name [here](https://github.com/preset-io/backend-sdk/blob/main/src/preset_cli/cli/superset/sync/dbt/command.py#L137), which could cause https://github.com/preset-io/backend-sdk/issues/208
* The asset titles were used as the `name` for exposures, which could contain [incompatible characters](https://docs.getdbt.com/reference/exposure-properties): https://github.com/preset-io/backend-sdk/issues/207 and https://github.com/preset-io/backend-sdk/issues/177
* Charts don't have a `query_context` value until they are viewed in Explore, which could cause: https://github.com/preset-io/backend-sdk/issues/206

This PR also introduces a new flag to the dbt sync: ``--preserve-columns``. By default, the sync would update existing datasets in Superset with ``override_columns=True``, which resets the column definition (`groupby` and `filterable` configurations) and also sync columns from the dataset. This could potentially misconfigure existing columns in Superset, or bring back to the datasets columns that were intentionally excluded. This behavior will be kept by default (since the main use-case for the dbt integration is to have the dbt info as the source of truth), however if the ``--preserve-columns`` flag is included in the dbt sync command, the update dataset API calls would include ``override_columns=False``, preserving column configurations and avoiding a column sync.