### PR TITLE
(fix)get_role_id() was returning multiple results

### DIFF
--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -1006,7 +1006,7 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
         """
         Return the ID of a given role.
         """
-        params = {"_flt_0_name": role_name}
+        params = {"_flt_3_name": role_name}
         url = self.baseurl / "roles/list/"
         _logger.debug("GET %s", url % params)
         response = self.session.get(url, params=params)

--- a/tests/api/clients/superset_test.py
+++ b/tests/api/clients/superset_test.py
@@ -2151,7 +2151,7 @@ def test_import_rls(requests_mock: Mocker) -> None:
         json={"result": []},
     )
     requests_mock.get(
-        "https://superset.example.org/roles/list/?_flt_0_name=Gamma",
+        "https://superset.example.org/roles/list/?_flt_3_name=Gamma",
         text="""
 <!DOCTYPE html>
 <html lang="en">
@@ -2242,7 +2242,7 @@ def test_import_rls_no_role_table(requests_mock: Mocker) -> None:
         json={"result": []},
     )
     requests_mock.get(
-        "https://superset.example.org/roles/list/?_flt_0_name=Gamma",
+        "https://superset.example.org/roles/list/?_flt_3_name=Gamma",
         text="""
 <!DOCTYPE html>
 <html lang="en">
@@ -2297,7 +2297,7 @@ def test_import_rls_invalid_role(requests_mock: Mocker) -> None:
         json={"result": []},
     )
     requests_mock.get(
-        "https://superset.example.org/roles/list/?_flt_0_name=Gamma",
+        "https://superset.example.org/roles/list/?_flt_3_name=Gamma",
         text="""
 <!DOCTYPE html>
 <html lang="en">
@@ -2381,7 +2381,7 @@ def test_import_rls_no_schema(requests_mock: Mocker) -> None:
         json={"result": []},
     )
     requests_mock.get(
-        "https://superset.example.org/roles/list/?_flt_0_name=Gamma",
+        "https://superset.example.org/roles/list/?_flt_3_name=Gamma",
         text="""
 <!DOCTYPE html>
 <html lang="en">
@@ -2542,7 +2542,7 @@ def test_import_rls_no_role(requests_mock: Mocker) -> None:
         json={"result": []},
     )
     requests_mock.get(
-        "https://superset.example.org/roles/list/?_flt_0_name=Gamma",
+        "https://superset.example.org/roles/list/?_flt_3_name=Gamma",
         text="""
 <!DOCTYPE html>
 <html lang="en">
@@ -2603,7 +2603,7 @@ def test_import_rls_multiple_roles(requests_mock: Mocker) -> None:
         json={"result": []},
     )
     requests_mock.get(
-        "https://superset.example.org/roles/list/?_flt_0_name=Gamma",
+        "https://superset.example.org/roles/list/?_flt_3_name=Gamma",
         text="""
 <!DOCTYPE html>
 <html lang="en">
@@ -2670,7 +2670,7 @@ def test_import_rls_anchor_role_id(requests_mock: Mocker) -> None:
         json={"result": []},
     )
     requests_mock.get(
-        "https://superset.example.org/roles/list/?_flt_0_name=Gamma",
+        "https://superset.example.org/roles/list/?_flt_3_name=Gamma",
         text="""
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
The `get_role_id()` function was previously configured to use ``{"_flt_0_name": role_name}``. The ``0`` filter index is used for **Starts with**, so in case there are more than one DARs starting with the same name from the YAML file, multiple results would be returned.

This PR changes the filter index to ``3`` which is used for the **Equals** filter operator. The ``3`` filter operator was already being used [here](https://github.com/preset-io/backend-sdk/blob/main/src/preset_cli/api/clients/superset.py#L920), so this should be a minor change.