### PR TITLE
fix(dbt-cloud-sync): Support null git_provider_id

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Changelog
 Next
 ====
 
+Version 0.2.4 - 2023-07-20
+==========================
+
+- Further adjustments to dbt marshmallow schemas to avoid integration errors (`#228 <https://github.com/preset-io/backend-sdk/pull/228>_`).
+- Export RLS rules is now compatible with Preset Cloud and older Superset installations (`#227 <https://github.com/preset-io/backend-sdk/pull/227>_`)
+
 Version 0.2.3 - 2023-07-14
 ==========================
 

--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -375,7 +375,7 @@ class RepositorySchema(PostelSchema):
     gitlab = fields.String(allow_none=True)
     name = fields.String()
     pull_request_url_template = fields.String(allow_none=True)
-    git_provider_id = fields.Integer()
+    git_provider_id = fields.Integer(allow_none=True)
     git_provider = fields.String(allow_none=True)
     project_id = fields.Integer()
     deploy_key = fields.Nested(DeployKeySchema)


### PR DESCRIPTION
Support `null` values for the `git_provider_id` field (`RepositorySchema`).