### PR TITLE
fix(session): Implement retry mechanism for closed connections

### DIFF
--- a/src/preset_cli/auth/main.py
+++ b/src/preset_cli/auth/main.py
@@ -5,8 +5,8 @@ Mechanisms for authentication and authorization.
 from typing import Any, Dict
 
 from requests import Response, Session
-from urllib3.util import Retry
 from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
 
 
 class Auth:  # pylint: disable=too-few-public-methods
@@ -20,8 +20,8 @@ class Auth:  # pylint: disable=too-few-public-methods
 
         retries = Retry(
             total=3,  # max retries count
-            backoff_factor=0.2,  # delay factor between attempts
-            # respect_retry_after_header=True,
+            backoff_factor=1,  # delay factor between attempts
+            respect_retry_after_header=True,
         )
 
         self.session.mount("https://", HTTPAdapter(max_retries=retries))

--- a/src/preset_cli/auth/main.py
+++ b/src/preset_cli/auth/main.py
@@ -5,6 +5,8 @@ Mechanisms for authentication and authorization.
 from typing import Any, Dict
 
 from requests import Response, Session
+from urllib3.util import Retry
+from requests.adapters import HTTPAdapter
 
 
 class Auth:  # pylint: disable=too-few-public-methods
@@ -15,6 +17,14 @@ class Auth:  # pylint: disable=too-few-public-methods
     def __init__(self):
         self.session = Session()
         self.session.hooks["response"].append(self.reauth)
+
+        retries = Retry(
+            total=3,  # max retries count
+            backoff_factor=0.2,  # delay factor between attempts
+            # respect_retry_after_header=True,
+        )
+
+        self.session.mount("https://", HTTPAdapter(max_retries=retries))
 
     def get_headers(self) -> Dict[str, str]:
         """


### PR DESCRIPTION
By default, we create a session with the target server and re-use it during the process. However, the server might close the connection, so this PR introduces a `Retry` mechanism to prevent errors.  