### PR TITLE
fix(import/export): Improve Jinja handling logic

### DIFF
--- a/src/preset_cli/cli/superset/export.py
+++ b/src/preset_cli/cli/superset/export.py
@@ -153,7 +153,6 @@ def export_resource(  # pylint: disable=too-many-arguments, too-many-locals
             output.write(file_contents)
 
 
-# def process_value(value: Any) -> Any:
 def traverse_data(value: Any, handler: Callable) -> Any:
     """
     Process value according to its data type

--- a/src/preset_cli/cli/superset/export.py
+++ b/src/preset_cli/cli/superset/export.py
@@ -2,10 +2,11 @@
 A command to export Superset resources into a directory.
 """
 
+import json
 import re
 from collections import defaultdict
 from pathlib import Path
-from typing import List, Set, Tuple
+from typing import Any, Callable, List, Set, Tuple
 from zipfile import ZipFile
 
 import click
@@ -142,10 +143,41 @@ def export_resource(  # pylint: disable=too-many-arguments, too-many-locals
 
         # escape any pre-existing Jinja2 templates
         if not disable_jinja_escaping:
-            file_contents = jinja_escaper(file_contents)
+            asset_content = yaml.load(file_contents, Loader=yaml.SafeLoader)
+            for key, value in asset_content.items():
+                asset_content[key] = traverse_data(value, handle_string)
+
+            file_contents = yaml.dump(asset_content, sort_keys=False)
 
         with open(target, "w", encoding="utf-8") as output:
             output.write(file_contents)
+
+
+# def process_value(value: Any) -> Any:
+def traverse_data(value: Any, handler: Callable) -> Any:
+    """
+    Process value according to its data type
+    """
+    if isinstance(value, str):
+        return handler(value)
+    if isinstance(value, dict) and value:
+        return {k: traverse_data(v, handler) for k, v in value.items()}
+    if isinstance(value, list) and value:
+        return [traverse_data(item, handler) for item in value]
+    return value
+
+
+def handle_string(value):
+    """
+    Try to load string as JSON to traverse its content
+    """
+    try:
+        asset_dict = json.loads(value)
+        return (
+            json.dumps(traverse_data(asset_dict, jinja_escaper)) if asset_dict else "{}"
+        )
+    except json.JSONDecodeError:
+        return jinja_escaper(value)
 
 
 def jinja_escaper(value: str) -> str:

--- a/src/preset_cli/cli/superset/export.py
+++ b/src/preset_cli/cli/superset/export.py
@@ -168,7 +168,8 @@ def traverse_data(value: Any, handler: Callable) -> Any:
 
 def handle_string(value):
     """
-    Try to load string as JSON to traverse its content
+    Try to load a string as JSON to traverse its content for proper Jinja templating escaping.
+    Required for fields like ``query_context``
     """
     try:
         asset_dict = json.loads(value)

--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -103,7 +103,7 @@ def render_yaml(path: Path, env: Dict[str, Any]) -> Dict[str, Any]:
     try:
         template = Template(asset_content)
 
-    # For charts with a `query_context` (str(json)), templating the YAML structure directly
+    # For charts with a `query_context` -> ``str(JSON)``, templating the YAML structure directly
     # was failing. The route str(YAML) -> dict -> str(JSON) is more consistent.
     except TemplateSyntaxError:
         content = yaml.load(asset_content, Loader=yaml.SafeLoader)

--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -19,6 +19,7 @@ import click
 import requests
 import yaml
 from jinja2 import Template
+from jinja2.exceptions import TemplateSyntaxError
 from sqlalchemy.engine import create_engine
 from sqlalchemy.engine.url import make_url
 from yarl import URL
@@ -97,10 +98,19 @@ def render_yaml(path: Path, env: Dict[str, Any]) -> Dict[str, Any]:
     env["filepath"] = path
 
     with open(path, encoding="utf-8") as input_:
-        template = Template(input_.read())
+        asset_content = input_.read()
+
+    try:
+        template = Template(asset_content)
+
+    # For charts with a `query_context` (str(json)), templating the YAML structure directly
+    # was failing. The route str(YAML) -> dict -> str(JSON) is more consistent.
+    except TemplateSyntaxError:
+        content = yaml.load(asset_content, Loader=yaml.SafeLoader)
+        content = json.dumps(content)
+        template = Template(content)
 
     content = template.render(**env)
-
     return yaml.load(content, Loader=yaml.SafeLoader)
 
 

--- a/tests/cli/superset/export_test.py
+++ b/tests/cli/superset/export_test.py
@@ -60,12 +60,12 @@ GROUP BY action""",
                     "slice_id": 1,
                     "metric": {
                         "expressionType": "SQL",
-                        "sqlExpression": "COUNT(*)",
+                        "sqlExpression": "{% if from_dttm %} count(*) {% else %} count(*) {% endif %}",
                         "column": None,
                         "aggregate": None,
                         "datasourceWarning": False,
-                        "hasCustomLabel": False,
-                        "label": "count",
+                        "hasCustomLabel": True,
+                        "label": "custom_calculation",
                         "optionName": "metric_6aq7h4t8b3t_jbp2rak398o",
                     },
                     "adhoc_filters": [],
@@ -75,16 +75,16 @@ GROUP BY action""",
                     "time_format": "smart_date",
                     "extra_form_data": {},
                     "dashboards": [],
-                    "query_context": """
-{"datasource":{"id":1,"type":"table"},"force":false,"queries":[{"filters":[],"extras":{"having":"","where":""},
-"applied_time_extras":{},"columns":[],"metrics":[{"expressionType":"SQL","sqlExpression":"COUNT(*)","column":null,
-"aggregate":null,"datasourceWarning":false,"hasCustomLabel":false,"label":"count","optionName":"metric_6aq7h4t8b3t_jbp2rak398o"}],
-"annotation_layers":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{}}],
-"form_data":{"datasource":"1__table","viz_type":"big_number_total","slice_id":1,"metric":{"expressionType":"SQL","sqlExpression":"COUNT(*)",
-"column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":false,"label":"count","optionName":"metric_6aq7h4t8b3t_jbp2rak398o"},
-"adhoc_filters":[],"header_font_size":0.4,"subheader_font_size":0.15,"y_axis_format":"SMART_NUMBER","time_format":"smart_date",
-"extra_form_data":{},"dashboards":[],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}""",
                 },
+                "query_context": """
+{"datasource":{"id":1,"type":"table"},"force":false,"queries":[{"filters":[],"extras":{"having":"","where":""},"applied_time_extras":{},
+"columns":[],"metrics":[{"expressionType":"SQL","sqlExpression":"{% if from_dttm %} count(*) {% else %} count(*) {% endif %}","column":null,"aggregate":null,
+"datasourceWarning":false,"hasCustomLabel":true,"label":"custom_calculation","optionName":"metric_6aq7h4t8b3t_jbp2rak398o"}],"annotation_layers":[],
+"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{}}],"form_data":{"datasource":"1__table","viz_type":"big_number_total",
+"slice_id":1,"metric":{"expressionType":"SQL","sqlExpression":"{% if from_dttm %} count(*) {% else %} count(*) {% endif %}","column":null,"aggregate":null,
+"datasourceWarning":false,"hasCustomLabel":true,"label":"custom_calculation","optionName":"metric_6aq7h4t8b3t_jbp2rak398o"},"adhoc_filters":[],"header_font_size":0.4,
+"subheader_font_size":0.15,"y_axis_format":"SMART_NUMBER","time_format":"smart_date","extra_form_data":{},"dashboards":[],"force":false,"result_format":"json","result_type":"full"},
+"result_format":"json","result_type":"full"}""",
             },
         ),
     }
@@ -148,7 +148,7 @@ FROM logs
 GROUP BY action""",
         }
 
-    # check that chart JSON strcuture was not escaped
+    # check that chart JSON strcuture was not escaped, only Jinja
     export_resource(
         resource_name="chart",
         requested_ids=set(),
@@ -158,10 +158,14 @@ GROUP BY action""",
         disable_jinja_escaping=False,
     )
     with open(root / "charts/test_01.yaml", encoding="utf-8") as input_:
+        # load `query_context` as JSON to avoid
+        # issues due to blank spaces, quotes, etc
         input__ = yaml.load(input_.read(), Loader=yaml.SafeLoader)
-        input__["params"]["query_context"] = json.loads(
-            input__["params"]["query_context"],
+        print(input__["query_context"])
+        input__["query_context"] = json.loads(
+            input__["query_context"],
         )
+        print(input__["query_context"])
         assert input__ == {
             "slice_name": "test",
             "viz_type": "big_number_total",
@@ -171,12 +175,12 @@ GROUP BY action""",
                 "slice_id": 1,
                 "metric": {
                     "expressionType": "SQL",
-                    "sqlExpression": "COUNT(*)",
+                    "sqlExpression": "{{ '{% if' }} from_dttm {{ '%}' }} count(*) {{ '{% else %}' }} count(*) {{ '{% endif %}' }}",
                     "column": None,
                     "aggregate": None,
                     "datasourceWarning": False,
-                    "hasCustomLabel": False,
-                    "label": "count",
+                    "hasCustomLabel": True,
+                    "label": "custom_calculation",
                     "optionName": "metric_6aq7h4t8b3t_jbp2rak398o",
                 },
                 "adhoc_filters": [],
@@ -186,18 +190,18 @@ GROUP BY action""",
                 "time_format": "smart_date",
                 "extra_form_data": {},
                 "dashboards": [],
-                "query_context": json.loads(
-                    """
-    {"datasource":{"id":1,"type":"table"},"force":false,"queries":[{"filters":[],"extras":{"having":"","where":""},
-    "applied_time_extras":{},"columns":[],"metrics":[{"expressionType":"SQL","sqlExpression":"COUNT(*)","column":null,
-    "aggregate":null,"datasourceWarning":false,"hasCustomLabel":false,"label":"count","optionName":"metric_6aq7h4t8b3t_jbp2rak398o"}],
-    "annotation_layers":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{}}],
-    "form_data":{"datasource":"1__table","viz_type":"big_number_total","slice_id":1,"metric":{"expressionType":"SQL","sqlExpression":"COUNT(*)",
-    "column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":false,"label":"count","optionName":"metric_6aq7h4t8b3t_jbp2rak398o"},
-    "adhoc_filters":[],"header_font_size":0.4,"subheader_font_size":0.15,"y_axis_format":"SMART_NUMBER","time_format":"smart_date",
-    "extra_form_data":{},"dashboards":[],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}""",
-                ),
             },
+            "query_context": json.loads(
+                """
+{"datasource":{"id":1,"type":"table"},"force":false,"queries":[{"filters":[],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[],
+"metrics":[{"expressionType":"SQL","sqlExpression":"{{ '{% if' }} from_dttm {{ '%}' }} count(*) {{ '{% else %}' }} count(*) {{ '{% endif %}' }}",
+"column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"custom_calculation","optionName":"metric_6aq7h4t8b3t_jbp2rak398o"}],
+"annotation_layers":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{}}],"form_data":{"datasource":"1__table",
+"viz_type":"big_number_total","slice_id":1,"metric":{"expressionType":"SQL","sqlExpression":"{{ '{% if' }} from_dttm {{ '%}' }} count(*) {{ '{% else %}' }} count(*) {{ '{% endif %}' }}",
+"column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"custom_calculation","optionName":"metric_6aq7h4t8b3t_jbp2rak398o"},
+"adhoc_filters":[],"header_font_size":0.4,"subheader_font_size":0.15,"y_axis_format":"SMART_NUMBER","time_format":"smart_date",
+"extra_form_data":{},"dashboards":[],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}""",
+            ),
         }
 
     # metadata file should be ignored

--- a/tests/cli/superset/export_test.py
+++ b/tests/cli/superset/export_test.py
@@ -148,7 +148,7 @@ FROM logs
 GROUP BY action""",
         }
 
-    # check that chart JSON strcuture was not escaped, only Jinja
+    # check that chart JSON structure was not escaped, only Jinja templating
     export_resource(
         resource_name="chart",
         requested_ids=set(),
@@ -159,7 +159,7 @@ GROUP BY action""",
     )
     with open(root / "charts/test_01.yaml", encoding="utf-8") as input_:
         # load `query_context` as JSON to avoid
-        # issues due to blank spaces, quotes, etc
+        # mismatches due to blank spaces, single vs double quotes, etc
         input__ = yaml.load(input_.read(), Loader=yaml.SafeLoader)
         print(input__["query_context"])
         input__["query_context"] = json.loads(


### PR DESCRIPTION
Since the CLI supports Jinja templating to dynamically modify the asset contents during the import, it automatically escapes existing Jinja templating syntax from assets during the export, so that they are ignored by the CLI renderer until import (and properly preserved to be handled by Superset). 

Recently the `query_context` was introduced to chart exports, which is a JSON structure converted to a string. The CLI was incorrectly escaping the JSON structure (`{"key_one: {"key_two: "value" {{ '}}' }}`) as if it was Jinja templating syntax during the export, causing the import to fail.

This PR improves the Jinja escaping logic, trying to load any string field as a JSON (the most common field is the `query_context` but we have other JSON fields that are exported as strings) so that only Jinja syntax is escaped.

It also improves the Jinja rendering logic during import, by performing a YAML -> JSON conversion in case a `TemplateSyntaxError` is raised.