### PR TITLE
chore(dbt-sync): Allow the specification of dbt models using their path

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -284,6 +284,7 @@ def load_profiles(
     return apply_templating(profiles)
 
 
+# pylint: disable=R0911
 def filter_models(models: List[ModelSchema], condition: str) -> List[ModelSchema]:
     """
     Filter a list of dbt models given a select condition.

--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -310,6 +310,18 @@ def filter_models(models: List[ModelSchema], condition: str) -> List[ModelSchema
     if condition in model_names:
         return [model_names[condition]]
 
+    # file
+    file_path = Path(condition)
+    if file_path.is_file() and file_path.stem in model_names:
+        return [model_names[condition]]
+
+    # path/directory
+    if file_path.is_dir() or str(file_path).endswith("/*"):
+        sql_files = [file for file in file_path.rglob("*.sql") if file.is_file()]
+        for file in sql_files:
+            if file.stem in model_names:
+                return [model_names[condition]]
+
     # plus and n-plus operators
     if "+" in condition:
         return filter_plus_operator(models, condition)

--- a/tests/cli/superset/sync/dbt/lib_test.py
+++ b/tests/cli/superset/sync/dbt/lib_test.py
@@ -558,6 +558,7 @@ def test_apply_select_exclude() -> None:
     assert {model["name"] for model in apply_select(models, ("a",), ("d",))} == {"a"}
 
 
+# pylint: disable=unused-argument
 def test_apply_select_using_path(fs: FakeFilesystem) -> None:
     """
     Test ``apply_select`` using directory/path arguments.

--- a/tests/cli/superset/sync/dbt/lib_test.py
+++ b/tests/cli/superset/sync/dbt/lib_test.py
@@ -556,3 +556,65 @@ def test_apply_select_exclude() -> None:
     }
     assert {model["name"] for model in apply_select(models, (), ("b+", "c+"))} == {"a"}
     assert {model["name"] for model in apply_select(models, ("a",), ("d",))} == {"a"}
+
+
+def test_apply_select_using_path(fs: FakeFilesystem) -> None:
+    """
+    Test ``apply_select`` using directory/path arguments.
+    """
+    one = {
+        "name": "one",
+        "tags": ["test"],
+        "unique_id": "model.one",
+        "depends_on": ["source.zero"],
+        "children": ["model.two"],
+    }
+    two = {
+        "name": "two",
+        "tags": [],
+        "unique_id": "model.two",
+        "depends_on": ["model.one", "model.three"],
+        "children": [],
+    }
+    three = {
+        "name": "three",
+        "tags": [],
+        "unique_id": "model.three",
+        "depends_on": ["source.zero"],
+        "children": ["model.two"],
+    }
+    models: List[ModelSchema] = [one, two, three]  # type: ignore
+
+    base_dir = Path("models")
+    base_dir.mkdir(exist_ok=True)
+    (base_dir / "one.sql").write_text(json.dumps(one))
+
+    test_folder = base_dir / "test_folder"
+    test_folder.mkdir(exist_ok=True)
+    (test_folder / "two.sql").write_text(json.dumps(two))
+
+    test_second_folder = test_folder / "test_second_folder"
+    test_second_folder.mkdir(exist_ok=True)
+    (test_second_folder / "three.sql").write_text(json.dumps(three))
+
+    assert {model["name"] for model in apply_select(models, ("models",), ())} == {
+        "one",
+        "two",
+        "three",
+    }
+    assert {
+        model["name"] for model in apply_select(models, ("models/one.sql",), ())
+    } == {
+        "one",
+    }
+    assert {model["name"] for model in apply_select(models, ("models/",), ())} == {
+        "one",
+        "two",
+        "three",
+    }
+    assert {
+        model["name"] for model in apply_select(models, ("models/test_folder/*",), ())
+    } == {
+        "two",
+        "three",
+    }


### PR DESCRIPTION
This PR adds the ability to specify the models that should be synced using their relative path. Both specifying files (for example `--select models/my_model.sql`) and folders (for example `--select models/prod`) work. When selecting a folder, it supports the inclusion or not of the last trailing slash(`--select models/prod == --select models/prod/`). 

It's also possible to use `*` after the folder name, however for this approach it's required to pass the argument as a string -> `--select "models/prod/*"` otherwise the terminal automatically creates one argument per file, breaking the CLI.

Implements https://github.com/preset-io/backend-sdk/issues/217 and https://github.com/preset-io/backend-sdk/issues/171.