### PR TITLE
chore(dbt cloud): return job instead of job ID

### DIFF
--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -3,7 +3,7 @@ A simple client for running SQL queries (and more) against Superset:
 
     >>> from yarl import URL
     >>> from preset_cli.api.clients.superset import SupersetClient
-    >>> from preset_cli.auth.password import UsernamePasswordAuth
+    >>> from preset_cli.auth.superset import UsernamePasswordAuth
     >>> url = URL("http://localhost:8088/")
     >>> auth = UsernamePasswordAuth(url, "admin", "admin")  # doctest: +SKIP
     >>> client = SupersetClient(url, auth)  # doctest: +SKIP


### PR DESCRIPTION
A refactor preparing the support for dbt 1.6. For the new semantic layer we need access to the environment ID, so we need the full job information, not just the ID.

Updated tests and added new ones.