### PR TITLE
chore (dbt): pass metric definition

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -708,7 +708,7 @@ class DBTClient:  # pylint: disable=too-few-public-methods
 
         return models
 
-    def get_metrics(self, job_id: int) -> List[Any]:
+    def get_og_metrics(self, job_id: int) -> List[Any]:
         """
         Fetch all available metrics.
         """

--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -136,6 +136,26 @@ def convert_to_adhoc_metric(expression: str) -> MetricType:
     }
 
 
+class SupersetMetricDefinition(TypedDict, total=False):
+    """
+    Definition of a Superset metric.
+
+    Used in the PUT API for datasets.
+    """
+
+    id: int
+    expression: str
+    metric_name: str
+    metric_type: str
+    verbose_name: str
+    description: str
+    extra: str
+    warning_text: str
+    d3format: str
+    currency: str
+    uuid: str
+
+
 class ColumnType(TypedDict):
     """
     Schema for an adhoc column in the Chart API.

--- a/src/preset_cli/cli/superset/sync/dbt/metrics.py
+++ b/src/preset_cli/cli/superset/sync/dbt/metrics.py
@@ -6,25 +6,27 @@ This module is used to convert dbt metrics into Superset metrics.
 
 # pylint: disable=consider-using-f-string
 
+import json
 import logging
-from typing import Dict, List
+from typing import Dict, List, Set
 
 import sqlparse
 from sqlparse.sql import Identifier, TokenList
 
 from preset_cli.api.clients.dbt import FilterSchema, MetricSchema, ModelSchema
+from preset_cli.api.clients.superset import SupersetMetricDefinition
 
 _logger = logging.getLogger(__name__)
 
 
-def get_metric_expression(metric_name: str, metrics: Dict[str, MetricSchema]) -> str:
+def get_metric_expression(unique_id: str, metrics: Dict[str, MetricSchema]) -> str:
     """
     Return a SQL expression for a given dbt metric.
     """
-    if metric_name not in metrics:
-        raise Exception(f"Invalid metric {metric_name}")
+    if unique_id not in metrics:
+        raise Exception(f"Invalid metric {unique_id}")
 
-    metric = metrics[metric_name]
+    metric = metrics[unique_id]
     if "calculation_method" in metric:
         # dbt >= 1.3
         type_ = metric["calculation_method"]
@@ -124,3 +126,45 @@ def get_metrics_for_model(
             related_metrics.append(metric)
 
     return related_metrics
+
+
+def get_metric_models(unique_id: str, metrics: List[MetricSchema]) -> Set[str]:
+    """
+    Given a metric, return the models it depends on.
+    """
+    metric_map = {metric["unique_id"]: metric for metric in metrics}
+    metric = metric_map[unique_id]
+    depends_on = metric["depends_on"]
+
+    if is_derived(metric):
+        return {
+            model
+            for parent in depends_on
+            for model in get_metric_models(parent, metrics)
+        }
+
+    return set(depends_on)
+
+
+def get_metric_definition(
+    unique_id: str,
+    metrics: List[MetricSchema],
+) -> SupersetMetricDefinition:
+    """
+    Build a Superset metric definition from an OG (< 1.6) dbt metric.
+    """
+    metric_map = {metric["unique_id"]: metric for metric in metrics}
+    metric = metric_map[unique_id]
+    name = metric["name"]
+    meta = metric.get("meta", {})
+    kwargs = meta.pop("superset", {})
+
+    return {
+        "expression": get_metric_expression(unique_id, metric_map),
+        "metric_name": name,
+        "metric_type": (metric.get("type") or metric.get("calculation_method")),
+        "verbose_name": metric.get("label", name),
+        "description": metric.get("description", ""),
+        "extra": json.dumps(meta),
+        **kwargs,  # type: ignore
+    }

--- a/tests/api/clients/dbt_test.py
+++ b/tests/api/clients/dbt_test.py
@@ -1152,9 +1152,9 @@ def test_dbt_client_get_models(mocker: MockerFixture) -> None:
     ]
 
 
-def test_dbt_client_get_metrics(mocker: MockerFixture) -> None:
+def test_dbt_client_get_og_metrics(mocker: MockerFixture) -> None:
     """
-    Test the ``get_metrics`` method.
+    Test the ``get_og_metrics`` method.
     """
     GraphqlClient = mocker.patch("preset_cli.api.clients.dbt.GraphqlClient")
     GraphqlClient().execute.return_value = {
@@ -1178,7 +1178,7 @@ def test_dbt_client_get_metrics(mocker: MockerFixture) -> None:
     }
     auth = Auth()
     client = DBTClient(auth)
-    assert client.get_metrics(108380) == [
+    assert client.get_og_metrics(108380) == [
         {
             "meta": {},
             "name": "new_customers",

--- a/tests/cli/superset/sync/dbt/command_test.py
+++ b/tests/cli/superset/sync/dbt/command_test.py
@@ -126,6 +126,19 @@ dbt_core_metrics = [
     },
 ]
 
+superset_metrics = {
+    "model.superset_examples.messages_channels": [
+        {
+            "description": "",
+            "expression": "COUNT(*)",
+            "extra": "{}",
+            "metric_name": "cnt",
+            "metric_type": "count",
+            "verbose_name": "",
+        },
+    ],
+}
+
 dbt_cloud_models = [
     {
         "database": "examples_dev",
@@ -148,6 +161,17 @@ dbt_cloud_metrics = [
         "sql": "*",
         "type": "count",
         "unique_id": "metric.superset_examples.cnt",
+    },
+    {
+        "depends_on": ["a", "b"],
+        "description": "",
+        "filters": [],
+        "label": "",
+        "meta": {},
+        "name": "multiple parents",
+        "sql": "*",
+        "type": "count",
+        "unique_id": "c",
     },
 ]
 
@@ -210,7 +234,7 @@ def test_dbt_core(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     sync_datasets.assert_called_with(
         client,
         dbt_core_models,
-        dbt_core_metrics,
+        superset_metrics,
         sync_database(),
         False,
         "",
@@ -287,7 +311,7 @@ def test_dbt_core_preserve_metadata(
     sync_datasets.assert_called_with(
         client,
         dbt_core_models,
-        dbt_core_metrics,
+        superset_metrics,
         sync_database(),
         False,
         "",
@@ -357,7 +381,7 @@ def test_dbt_core_preserve_columns(
     sync_datasets.assert_called_with(
         client,
         dbt_core_models,
-        dbt_core_metrics,
+        superset_metrics,
         sync_database(),
         False,
         "",
@@ -428,7 +452,7 @@ def test_dbt_core_merge_metadata(
     sync_datasets.assert_called_with(
         client,
         dbt_core_models,
-        dbt_core_metrics,
+        superset_metrics,
         sync_database(),
         False,
         "",
@@ -700,37 +724,10 @@ def test_dbt(mocker: MockerFixture, fs: FakeFilesystem) -> None:
             "refs": [],
         },
     ]
-    metrics = [
-        {
-            "meta": {},
-            "depends_on": ["model.superset_examples.messages_channels"],
-            "unique_id": "metric.superset_examples.cnt",
-            "label": "",
-            "sql": "*",
-            "type": "count",
-            "name": "cnt",
-            "description": "",
-            "filters": [],
-            "model": "ref('messages_channels')",
-            "sources": [],
-            "original_file_path": "models/slack/schema.yml",
-            "resource_type": "metric",
-            "tags": [],
-            "path": "slack/schema.yml",
-            "created_at": 1642630986.1942852,
-            "fqn": ["superset_examples", "slack", "cnt"],
-            "package_name": "superset_examples",
-            "timestamp": None,
-            "root_path": "/Users/beto/Projects/dbt-examples/superset_examples",
-            "time_grains": [],
-            "refs": [["messages_channels"]],
-            "dimensions": [],
-        },
-    ]
     sync_datasets.assert_called_with(
         client,
         models,
-        metrics,
+        superset_metrics,
         sync_database(),
         False,
         "",
@@ -966,7 +963,7 @@ def test_dbt_cloud(mocker: MockerFixture) -> None:
     )
 
     dbt_client.get_models.return_value = dbt_cloud_models
-    dbt_client.get_metrics.return_value = dbt_cloud_metrics
+    dbt_client.get_og_metrics.return_value = dbt_cloud_metrics
     database = mocker.MagicMock()
     superset_client.get_databases.return_value = [database]
     superset_client.get_database.return_value = database
@@ -987,7 +984,7 @@ def test_dbt_cloud(mocker: MockerFixture) -> None:
     sync_datasets.assert_called_with(
         superset_client,
         dbt_cloud_models,
-        dbt_cloud_metrics,
+        superset_metrics,
         database,
         False,
         "",
@@ -1018,7 +1015,7 @@ def test_dbt_cloud_preserve_metadata(mocker: MockerFixture) -> None:
     )
 
     dbt_client.get_models.return_value = dbt_cloud_models
-    dbt_client.get_metrics.return_value = dbt_cloud_metrics
+    dbt_client.get_og_metrics.return_value = dbt_cloud_metrics
     database = mocker.MagicMock()
     superset_client.get_databases.return_value = [database]
     superset_client.get_database.return_value = database
@@ -1040,7 +1037,7 @@ def test_dbt_cloud_preserve_metadata(mocker: MockerFixture) -> None:
     sync_datasets.assert_called_with(
         superset_client,
         dbt_cloud_models,
-        dbt_cloud_metrics,
+        superset_metrics,
         database,
         False,
         "",
@@ -1071,7 +1068,7 @@ def test_dbt_cloud_preserve_columns(mocker: MockerFixture) -> None:
     )
 
     dbt_client.get_models.return_value = dbt_cloud_models
-    dbt_client.get_metrics.return_value = dbt_cloud_metrics
+    dbt_client.get_og_metrics.return_value = dbt_cloud_metrics
     database = mocker.MagicMock()
     superset_client.get_databases.return_value = [database]
     superset_client.get_database.return_value = database
@@ -1093,7 +1090,7 @@ def test_dbt_cloud_preserve_columns(mocker: MockerFixture) -> None:
     sync_datasets.assert_called_with(
         superset_client,
         dbt_cloud_models,
-        dbt_cloud_metrics,
+        superset_metrics,
         database,
         False,
         "",
@@ -1124,7 +1121,7 @@ def test_dbt_cloud_merge_metadata(mocker: MockerFixture) -> None:
     )
 
     dbt_client.get_models.return_value = dbt_cloud_models
-    dbt_client.get_metrics.return_value = dbt_cloud_metrics
+    dbt_client.get_og_metrics.return_value = dbt_cloud_metrics
     database = mocker.MagicMock()
     superset_client.get_databases.return_value = [database]
     superset_client.get_database.return_value = database
@@ -1146,7 +1143,7 @@ def test_dbt_cloud_merge_metadata(mocker: MockerFixture) -> None:
     sync_datasets.assert_called_with(
         superset_client,
         dbt_cloud_models,
-        dbt_cloud_metrics,
+        superset_metrics,
         database,
         False,
         "",
@@ -1197,7 +1194,7 @@ def test_dbt_cloud_no_job_id(mocker: MockerFixture) -> None:
     )
 
     dbt_client.get_models.return_value = dbt_cloud_models
-    dbt_client.get_metrics.return_value = dbt_cloud_metrics
+    dbt_client.get_og_metrics.return_value = dbt_cloud_metrics
     dbt_client.get_accounts.return_value = [{"id": 1, "name": "My account"}]
     dbt_client.get_projects.return_value = [{"id": 1000, "name": "My project"}]
     dbt_client.get_jobs.return_value = [{"id": 123, "name": "My job"}]
@@ -1219,11 +1216,11 @@ def test_dbt_cloud_no_job_id(mocker: MockerFixture) -> None:
     assert result.exit_code == 0
     dbt_client.get_database_name.assert_called_with(123)
     dbt_client.get_models.assert_called_with(123)
-    dbt_client.get_metrics.assert_called_with(123)
+    dbt_client.get_og_metrics.assert_called_with(123)
     sync_datasets.assert_called_with(
         superset_client,
         dbt_cloud_models,
-        dbt_cloud_metrics,
+        superset_metrics,
         database,
         False,
         "",
@@ -1556,7 +1553,7 @@ def test_dbt_cloud_exposures_only(mocker: MockerFixture, fs: FakeFilesystem) -> 
     )
 
     dbt_client.get_models.return_value = dbt_cloud_models
-    dbt_client.get_metrics.return_value = dbt_cloud_metrics
+    dbt_client.get_og_metrics.return_value = dbt_cloud_metrics
     database = mocker.MagicMock()
     superset_client.get_databases.return_value = [database]
     superset_client.get_database.return_value = database

--- a/tests/cli/superset/sync/dbt/command_test.py
+++ b/tests/cli/superset/sync/dbt/command_test.py
@@ -867,7 +867,7 @@ def test_dbt_core_no_database(mocker: MockerFixture, fs: FakeFilesystem) -> None
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    assert result.output == "No database was found, pass ``--import-db`` to create\n"
+    assert "No database was found, pass ``--import-db`` to create" in result.output
 
 
 def test_dbt_core_disallow_edits_superset(

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -5,7 +5,7 @@ Tests for ``preset_cli.cli.superset.sync.dbt.datasets``.
 
 import copy
 import json
-from typing import List, cast
+from typing import Dict, List, cast
 from unittest import mock
 
 import pytest
@@ -13,6 +13,7 @@ from pytest_mock import MockerFixture
 from sqlalchemy.engine.url import make_url
 
 from preset_cli.api.clients.dbt import MetricSchema, ModelSchema
+from preset_cli.api.clients.superset import SupersetMetricDefinition
 from preset_cli.cli.superset.sync.dbt.datasets import (
     create_dataset,
     model_in_database,
@@ -20,21 +21,19 @@ from preset_cli.cli.superset.sync.dbt.datasets import (
 )
 
 metric_schema = MetricSchema()
-metrics: List[MetricSchema] = [
-    metric_schema.load(
+
+metrics: Dict[str, List[SupersetMetricDefinition]] = {
+    "model.superset_examples.messages_channels": [
         {
-            "depends_on": ["model.superset_examples.messages_channels"],
             "description": "",
-            "filters": [],
-            "meta": {},
-            "name": "cnt",
-            "label": "",
-            "sql": "*",
-            "type": "count",
-            "unique_id": "metric.superset_examples.cnt",
+            "expression": "COUNT(*)",
+            "extra": "{}",
+            "metric_name": "cnt",
+            "metric_type": "count",
+            "verbose_name": "",
         },
-    ),
-]
+    ],
+}
 
 model_schema = ModelSchema()
 models: List[ModelSchema] = [
@@ -234,7 +233,7 @@ def test_sync_datasets_no_metrics(mocker: MockerFixture) -> None:
     sync_datasets(
         client=client,
         models=models,
-        metrics=[],
+        metrics={},
         database={"id": 1, "sqlalchemy_uri": "postgresql://user@host/examples_dev"},
         disallow_edits=False,
         external_url_prefix="",
@@ -290,7 +289,7 @@ def test_sync_datasets_custom_certification(mocker: MockerFixture) -> None:
     sync_datasets(
         client=client,
         models=models,
-        metrics=[],
+        metrics={},
         database={"id": 1, "sqlalchemy_uri": "postgresql://user@host/examples_dev"},
         disallow_edits=False,
         external_url_prefix="",
@@ -523,18 +522,15 @@ def test_sync_datasets_preserve_metadata(mocker: MockerFixture) -> None:
     """
     client = mocker.MagicMock()
     metrics_ = copy.deepcopy(metrics)
-    metrics_.append(
+    metrics_["model.superset_examples.messages_channels"].append(
         metric_schema.load(
             {
-                "depends_on": ["model.superset_examples.messages_channels"],
                 "description": "",
-                "filters": [],
-                "meta": {},
-                "name": "max_id",
-                "label": "",
-                "sql": "id",
-                "type": "max",
-                "unique_id": "metric.superset_examples.cnt",
+                "expression": "MAX(id)",
+                "extra": "{}",
+                "metric_name": "max_id",
+                "metric_type": "max",
+                "verbose_name": "",
             },
         ),
     )
@@ -641,18 +637,15 @@ def test_sync_datasets_merge_metadata(mocker: MockerFixture) -> None:
     """
     client = mocker.MagicMock()
     metrics_ = copy.deepcopy(metrics)
-    metrics_.append(
+    metrics_["model.superset_examples.messages_channels"].append(
         metric_schema.load(
             {
-                "depends_on": ["model.superset_examples.messages_channels"],
                 "description": "",
-                "filters": [],
-                "meta": {},
-                "name": "max_id",
-                "label": "",
-                "sql": "id",
-                "type": "max",
-                "unique_id": "metric.superset_examples.cnt",
+                "expression": "MAX(id)",
+                "extra": "{}",
+                "metric_name": "max_id",
+                "metric_type": "max",
+                "verbose_name": "",
             },
         ),
     )

--- a/tests/cli/superset/sync/dbt/manifest.json
+++ b/tests/cli/superset/sync/dbt/manifest.json
@@ -1,5 +1,16 @@
 {
   "metrics": {
+    "c": {
+      "depends_on": {"nodes": ["a", "b"]},
+      "description": "",
+      "filters": [],
+      "label": "",
+      "meta": {},
+      "name": "multiple parents",
+      "sql": "*",
+      "type": "count",
+      "unique_id": "c"
+    },
     "metric.superset_examples.cnt": {
       "fqn": [
         "superset_examples",


### PR DESCRIPTION
When syncing metrics in the dbt command, we currently pass the metrics as `List[MetricSchema]` to `sync_datasets`, where `MetricSchema` is the schema returned by dbt Core/Cloud. This PR refactors the logic so we pass instead the metric in the schema that Superset uses. This will simplify the work needed to support dbt 1.6, which introduces yet another format for metrics.

Note that this PR is stacked upon https://github.com/preset-io/backend-sdk/pull/253.