### PR TITLE
feat(dbt): sync metrics from MetricFlow

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -67,6 +67,7 @@ rich==12.5.1
 six==1.16.0
 soupsieve==2.3.2.post1
 sqlalchemy==1.4.40
+sqlglot==20.7.1
 sqlparse==0.4.3
 tabulate==0.8.10
 toml==0.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ rich==12.3.0
 six==1.16.0
 soupsieve==2.3.2.post1
 sqlalchemy==1.4.35
+sqlglot==20.7.1
 sqlparse==0.4.3
 tabulate==0.8.9
 typing-extensions==4.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,7 @@ install_requires =
     requests>=2.26.0
     rich>=12.3.0
     sqlalchemy>=1.4,<2
+    sqlglot>=19
     sqlparse>=0.4.3
     tabulate>=0.8.9
     typing-extensions>=4.0.1

--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -611,7 +611,7 @@ class MFMetricSchema(PostelSchema):
     type = PostelEnumField(MFMetricType)
 
 
-class MFSQLEngineSchema(str, Enum):
+class MFSQLEngine(str, Enum):
     """
     Databases supported by MetricFlow.
     """
@@ -630,7 +630,7 @@ class MFMetricWithSQLSchema(MFMetricSchema):
     """
 
     sql = fields.String()
-    dialect = PostelEnumField(MFSQLEngineSchema)
+    dialect = PostelEnumField(MFSQLEngine)
     model = fields.String()
 
 
@@ -851,7 +851,7 @@ class DBTClient:  # pylint: disable=too-few-public-methods
 
         return payload["data"]["compileSql"]["sql"]
 
-    def get_sl_dialect(self, environment_id: int) -> str:
+    def get_sl_dialect(self, environment_id: int) -> MFSQLEngine:
         """
         Get the dialect used in the MetricFlow project.
         """
@@ -868,7 +868,7 @@ class DBTClient:  # pylint: disable=too-few-public-methods
             headers=self.session.headers,
         )
 
-        return payload["data"]["environmentInfo"]["dialect"]
+        return MFSQLEngine(payload["data"]["environmentInfo"]["dialect"])
 
     # def get_sl_metric_sql(self,
 

--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -24,7 +24,10 @@ from preset_cli.auth.main import Auth
 _logger = logging.getLogger(__name__)
 
 REST_ENDPOINT = URL("https://cloud.getdbt.com/")
-GRAPHQL_ENDPOINT = URL("https://metadata.cloud.getdbt.com/graphql")
+METADATA_GRAPHQL_ENDPOINT = URL("https://metadata.cloud.getdbt.com/graphql")
+SEMANTIC_LAYER_GRAPHQL_ENDPOINT = URL(
+    "https://semantic-layer.cloud.getdbt.com/api/graphql",
+)
 
 
 class PostelSchema(Schema):
@@ -472,7 +475,7 @@ class TimeSchema(PostelSchema):
 
 class StringOrSchema(fields.Field):
     """
-    Dynamic schema constructor for fields that could have a string or another schema
+    Dynamic schema constructor for fields that could have a string or another schema.
     """
 
     def __init__(self, nested_schema, *args, **kwargs):
@@ -587,6 +590,50 @@ class MetricSchema(PostelSchema):
     expression = fields.String()
 
 
+class MFMetricType(str, Enum):
+    """
+    Type of the MetricFlow metric.
+    """
+
+    SIMPLE = "SIMPLE"
+    RATIO = "RATIO"
+    CUMULATIVE = "CUMULATIVE"
+    DERIVED = "DERIVED"
+
+
+class MFMetricSchema(PostelSchema):
+    """
+    Schema for a MetricFlow metric.
+    """
+
+    name = fields.String()
+    description = fields.String()
+    type = PostelEnumField(MFMetricType)
+
+
+class MFSQLEngineSchema(str, Enum):
+    """
+    Databases supported by MetricFlow.
+    """
+
+    BIGQUERY = "BIGQUERY"
+    DUCKDB = "DUCKDB"
+    REDSHIFT = "REDSHIFT"
+    POSTGRES = "POSTGRES"
+    SNOWFLAKE = "SNOWFLAKE"
+    DATABRICKS = "DATABRICKS"
+
+
+class MFMetricWithSQLSchema(MFMetricSchema):
+    """
+    MetricFlow metric with dialect and SQL, as well as model.
+    """
+
+    sql = fields.String()
+    dialect = PostelEnumField(MFSQLEngineSchema)
+    model = fields.String()
+
+
 class DataResponse(TypedDict):
     """
     Type for the GraphQL response.
@@ -602,7 +649,10 @@ class DBTClient:  # pylint: disable=too-few-public-methods
     """
 
     def __init__(self, auth: Auth):
-        self.graphql_client = GraphqlClient(endpoint=GRAPHQL_ENDPOINT)
+        self.metadata_graphql_client = GraphqlClient(endpoint=METADATA_GRAPHQL_ENDPOINT)
+        self.semantic_layer_graphql_client = GraphqlClient(
+            endpoint=SEMANTIC_LAYER_GRAPHQL_ENDPOINT,
+        )
         self.baseurl = REST_ENDPOINT
 
         self.session = auth.session
@@ -610,16 +660,6 @@ class DBTClient:  # pylint: disable=too-few-public-methods
         self.session.headers["User-Agent"] = "Preset CLI"
         self.session.headers["X-Client-Version"] = __version__
         self.session.headers["X-dbt-partner-source"] = "preset"
-
-    def execute(self, query: str, **variables: Any) -> DataResponse:
-        """
-        Run a GraphQL query.
-        """
-        return self.graphql_client.execute(
-            query=query,
-            variables=variables,
-            headers=self.session.headers,
-        )
 
     def get_accounts(self) -> List[AccountSchema]:
         """
@@ -683,37 +723,46 @@ class DBTClient:  # pylint: disable=too-few-public-methods
         Fetch all available models.
         """
         query = """
-            query ($jobId: Int!) {
-                models(jobId: $jobId) {
-                    uniqueId
-                    dependsOn
-                    childrenL1
-                    name
-                    database
-                    schema
-                    description
-                    meta
-                    tags
-                    columns {
+            query Models($jobId: BigInt!) {
+                job(id: $jobId) {
+                    models {
+                        uniqueId
+                        dependsOn
+                        childrenL1
                         name
+                        database
+                        schema
                         description
+                        meta
+                        tags
+                        columns {
+                            name
+                            description
+                            type
+                        }
                     }
                 }
             }
         """
-        payload = self.execute(query, jobId=job_id)
+        payload = self.metadata_graphql_client.execute(
+            query=query,
+            variables={"jobId": job_id},
+            headers=self.session.headers,
+        )
 
         model_schema = ModelSchema()
-        models = [model_schema.load(model) for model in payload["data"]["models"]]
+        models = [
+            model_schema.load(model) for model in payload["data"]["job"]["models"]
+        ]
 
         return models
 
-    def get_og_metrics(self, job_id: int) -> List[Any]:
+    def get_og_metrics(self, job_id: int) -> List[MetricSchema]:
         """
         Fetch all available metrics.
         """
         query = """
-            query ($jobId: Int!) {
+            query GetMetrics($jobId: Int!) {
                 metrics(jobId: $jobId) {
                     uniqueId
                     name
@@ -731,12 +780,97 @@ class DBTClient:  # pylint: disable=too-few-public-methods
                 }
             }
         """
-        payload = self.execute(query, jobId=job_id)
+        payload = self.metadata_graphql_client.execute(
+            query=query,
+            variables={"jobId": job_id},
+            headers=self.session.headers,
+        )
 
         metric_schema = MetricSchema()
         metrics = [metric_schema.load(metric) for metric in payload["data"]["metrics"]]
 
         return metrics
+
+    def get_sl_metrics(self, environment_id: int) -> List[MFMetricSchema]:
+        """
+        Fetch all available metrics.
+        """
+        query = """
+            query GetMetrics($environmentId: BigInt!) {
+                metrics(environmentId: $environmentId) {
+                    name
+                    description
+                    type
+                }
+            }
+        """
+        payload = self.semantic_layer_graphql_client.execute(
+            query=query,
+            variables={"environmentId": environment_id},
+            headers=self.session.headers,
+        )
+
+        metric_schema = MFMetricSchema()
+        metrics = [metric_schema.load(metric) for metric in payload["data"]["metrics"]]
+
+        return metrics
+
+    def get_sl_metric_sql(self, metric: str, environment_id: int) -> Optional[str]:
+        """
+        Fetch metric SQL.
+
+        We fetch one metric at a time because if one metric fails to compile, the entire
+        query fails.
+        """
+        query = """
+            mutation CompileSql($environmentId: BigInt!, $metricsInput: [MetricInput!]) {
+                compileSql(
+                    environmentId: $environmentId
+                    metrics: $metricsInput
+                    groupBy: []
+                ) {
+                    sql
+                }
+            }
+        """
+        payload = self.semantic_layer_graphql_client.execute(
+            query=query,
+            variables={
+                "environmentId": environment_id,
+                "metricsInput": [{"name": metric}],
+            },
+            headers=self.session.headers,
+        )
+
+        if payload["data"] is None:
+            errors = "\n\n".join(
+                error["message"] for error in payload.get("errors", [])
+            )
+            _logger.warning("Unable to convert metric %s: %s", metric, errors)
+            return None
+
+        return payload["data"]["compileSql"]["sql"]
+
+    def get_sl_dialect(self, environment_id: int) -> str:
+        """
+        Get the dialect used in the MetricFlow project.
+        """
+        query = """
+            query GetEnvironmentInfo($environmentId: BigInt!) {
+                environmentInfo(environmentId: $environmentId) {
+                    dialect
+                }
+            }
+        """
+        payload = self.semantic_layer_graphql_client.execute(
+            query=query,
+            variables={"environmentId": environment_id},
+            headers=self.session.headers,
+        )
+
+        return payload["data"]["environmentInfo"]["dialect"]
+
+    # def get_sl_metric_sql(self,
 
     def get_database_name(self, job_id: int) -> str:
         """

--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -472,8 +472,8 @@ def dbt_cloud(  # pylint: disable=too-many-arguments, too-many-locals
                         "sql": sql,
                         "dialect": dialect,
                         "model": model["unique_id"],
-                    }
-                )
+                    },
+                ),
             )
 
     superset_metrics = get_superset_metrics_per_model(og_metrics, sl_metrics)

--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -470,7 +470,7 @@ def dbt_cloud(  # pylint: disable=too-many-arguments, too-many-locals
                         "type": metric["type"],
                         "description": metric["description"],
                         "sql": sql,
-                        "dialect": dialect,
+                        "dialect": dialect.value,
                         "model": model["unique_id"],
                     },
                 ),

--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -6,20 +6,30 @@ import os.path
 import sys
 import warnings
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import click
 import yaml
 from yarl import URL
 
-from preset_cli.api.clients.dbt import DBTClient, JobSchema, MetricSchema, ModelSchema
+from preset_cli.api.clients.dbt import (
+    DBTClient,
+    JobSchema,
+    MetricSchema,
+    MFMetricWithSQLSchema,
+    ModelSchema,
+)
 from preset_cli.api.clients.superset import SupersetClient
 from preset_cli.auth.token import TokenAuth
 from preset_cli.cli.superset.sync.dbt.databases import sync_database
 from preset_cli.cli.superset.sync.dbt.datasets import sync_datasets
 from preset_cli.cli.superset.sync.dbt.exposures import ModelKey, sync_exposures
 from preset_cli.cli.superset.sync.dbt.lib import apply_select
-from preset_cli.cli.superset.sync.dbt.metrics import get_superset_metrics_per_model
+from preset_cli.cli.superset.sync.dbt.metrics import (
+    MultipleModelsError,
+    get_model_from_sql,
+    get_superset_metrics_per_model,
+)
 from preset_cli.exceptions import DatabaseNotFoundError
 
 
@@ -181,10 +191,7 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-branches, too-many
             config["columns"] = list(config["columns"].values())
             models.append(model_schema.load(config))
     models = apply_select(models, select, exclude)
-    model_map = {
-        ModelKey(model["schema"], model["name"]): f"ref('{model['name']}')"
-        for model in models
-    }
+    model_map = {ModelKey(model["schema"], model["name"]): model for model in models}
 
     if exposures_only:
         datasets = [
@@ -439,13 +446,37 @@ def dbt_cloud(  # pylint: disable=too-many-arguments, too-many-locals
 
     models = dbt_client.get_models(job["id"])
     models = apply_select(models, select, exclude)
-    model_map = {
-        ModelKey(model["schema"], model["name"]): f"ref('{model['name']}')"
-        for model in models
-    }
+    model_map = {ModelKey(model["schema"], model["name"]): model for model in models}
 
+    # original dbt <= 1.6 metrics
     og_metrics = dbt_client.get_og_metrics(job["id"])
-    superset_metrics = get_superset_metrics_per_model(og_metrics)
+
+    # MetricFlow metrics
+    dialect = dbt_client.get_sl_dialect(job["environment_id"])
+    mf_metric_schema = MFMetricWithSQLSchema()
+    sl_metrics: List[MFMetricWithSQLSchema] = []
+    for metric in dbt_client.get_sl_metrics(job["environment_id"]):
+        sql = dbt_client.get_sl_metric_sql(metric["name"], job["environment_id"])
+        if sql is not None:
+            try:
+                model = get_model_from_sql(sql, dialect, model_map)
+            except MultipleModelsError:
+                continue
+
+            sl_metrics.append(
+                mf_metric_schema.load(
+                    {
+                        "name": metric["name"],
+                        "type": metric["type"],
+                        "description": metric["description"],
+                        "sql": sql,
+                        "dialect": dialect,
+                        "model": model["unique_id"],
+                    }
+                )
+            )
+
+    superset_metrics = get_superset_metrics_per_model(og_metrics, sl_metrics)
 
     if exposures_only:
         datasets = [

--- a/src/preset_cli/cli/superset/sync/dbt/metrics.py
+++ b/src/preset_cli/cli/superset/sync/dbt/metrics.py
@@ -9,15 +9,36 @@ This module is used to convert dbt metrics into Superset metrics.
 import json
 import logging
 from collections import defaultdict
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 import sqlparse
-from sqlparse.sql import Identifier, TokenList
+from sqlglot import Expression, parse_one
+from sqlglot.expressions import Alias, Case, Identifier, If, Join, Select, Table, Where
+from sqlglot.optimizer import traverse_scope
+from sqlparse.sql import Identifier as SQLParseIdentifier
+from sqlparse.sql import TokenList
 
-from preset_cli.api.clients.dbt import FilterSchema, MetricSchema, ModelSchema
+from preset_cli.api.clients.dbt import (
+    FilterSchema,
+    MetricSchema,
+    MFMetricWithSQLSchema,
+    MFSQLEngineSchema,
+    ModelSchema,
+)
 from preset_cli.api.clients.superset import SupersetMetricDefinition
+from preset_cli.cli.superset.sync.dbt.exposures import ModelKey
 
 _logger = logging.getLogger(__name__)
+
+# dbt => sqlglot
+DIALECT_MAP = {
+    MFSQLEngineSchema.BIGQUERY: "bigquery",
+    MFSQLEngineSchema.DUCKDB: "duckdb",
+    MFSQLEngineSchema.REDSHIFT: "redshift",
+    MFSQLEngineSchema.POSTGRES: "postgres",
+    MFSQLEngineSchema.SNOWFLAKE: "snowflake",
+    MFSQLEngineSchema.DATABRICKS: "databricks",
+}
 
 
 def get_metric_expression(unique_id: str, metrics: Dict[str, MetricSchema]) -> str:
@@ -61,7 +82,7 @@ def get_metric_expression(unique_id: str, metrics: Dict[str, MetricSchema]) -> s
         while tokens:
             token = tokens.pop(0)
 
-            if isinstance(token, Identifier) and token.value in metrics:
+            if isinstance(token, SQLParseIdentifier) and token.value in metrics:
                 parent_sql = get_metric_expression(token.value, metrics)
                 token.tokens = sqlparse.parse(parent_sql)[0].tokens
             elif isinstance(token, TokenList):
@@ -172,14 +193,15 @@ def get_metric_definition(
 
 
 def get_superset_metrics_per_model(
-    metrics: List[MetricSchema],
+    og_metrics: List[MetricSchema],
+    sl_metrics: Optional[List[MFMetricWithSQLSchema]] = None,
 ) -> Dict[str, List[SupersetMetricDefinition]]:
     """
     Build a dictionary of Superset metrics for each dbt model.
     """
     superset_metrics = defaultdict(list)
-    for metric in metrics:
-        metric_models = get_metric_models(metric["unique_id"], metrics)
+    for metric in og_metrics:
+        metric_models = get_metric_models(metric["unique_id"], og_metrics)
         if len(metric_models) != 1:
             _logger.warning(
                 "Metric %s cannot be calculated because it depends on multiple models: %s",
@@ -190,9 +212,145 @@ def get_superset_metrics_per_model(
 
         metric_definition = get_metric_definition(
             metric["unique_id"],
-            metrics,
+            og_metrics,
         )
         model = metric_models.pop()
         superset_metrics[model].append(metric_definition)
 
+    for sl_metric in sl_metrics or []:
+        metric_definition = convert_metric_flow_to_superset(
+            sl_metric["name"],
+            sl_metric["description"],
+            sl_metric["type"],
+            sl_metric["sql"],
+            sl_metric["dialect"],
+        )
+        model = sl_metric["model"]
+        superset_metrics[model].append(metric_definition)
+
     return superset_metrics
+
+
+def extract_aliases(parsed_query: Expression) -> Dict[str, str]:
+    """
+    Extract column aliases from a SQL query.
+    """
+    aliases = {}
+    for expression in parsed_query.find_all(Alias):
+        alias_name = expression.alias
+        expression_text = expression.this.sql()
+        aliases[alias_name] = expression_text
+
+    return aliases
+
+
+def convert_query_to_projection(sql: str, dialect: str) -> str:
+    """
+    Convert a MetricFlow compiled SQL to a projection.
+    """
+    parsed_query = parse_one(sql, dialect=DIALECT_MAP.get(dialect))
+
+    # extract aliases from inner query
+    scopes = traverse_scope(parsed_query)
+    has_subquery = len(scopes) > 1
+    aliases = extract_aliases(scopes[0].expression) if has_subquery else {}
+
+    # find the metric expression
+    select_expression = parsed_query.find(Select)
+    if select_expression.find(Join):
+        raise ValueError("Unable to convert metrics with JOINs")
+
+    projection = select_expression.args["expressions"]
+    if len(projection) > 1:
+        raise ValueError("Unable to convert metrics with multiple selected expressions")
+
+    metric_expression = (
+        projection[0].this if isinstance(projection[0], Alias) else projection[0]
+    )
+
+    # replace aliases with their original expressions
+    for node, _, _ in metric_expression.walk():
+        if isinstance(node, Identifier) and node.sql() in aliases:
+            node.replace(parse_one(aliases[node.sql()]))
+
+    # convert WHERE predicate to a CASE statement
+    where_expression = parsed_query.find(Where)
+    if where_expression:
+        for node, _, _ in where_expression.walk():
+            if isinstance(node, Identifier) and node.sql() in aliases:
+                node.replace(parse_one(aliases[node.sql()]))
+
+        case_expression = Case(
+            ifs=[If(this=where_expression.this, true=metric_expression.this)],
+        )
+        metric_expression.set("this", case_expression)
+
+    return metric_expression.sql()
+
+
+def convert_metric_flow_to_superset(
+    name: str,
+    description: str,
+    metric_type: str,
+    sql: str,
+    dialect: str,
+) -> SupersetMetricDefinition:
+    """
+    Convert a MetricFlow metric to a Superset metric.
+
+    Before MetricFlow we could build the metrics based on the metadata returned by the
+    GraphQL API. With MetricFlow we only have access to the compiled SQL used to
+    compute the metric, so we need to parse it and build a single projection for
+    Superset.
+
+    For example, this:
+
+        SELECT
+            SUM(order_count) AS large_order
+        FROM (
+            SELECT
+                order_total AS order_id__order_total_dim
+                , 1 AS order_count
+            FROM `dbt-tutorial-347100`.`dbt_beto`.`orders` orders_src_106
+        ) subq_796
+        WHERE order_id__order_total_dim >= 20
+
+    Becomes:
+
+        SUM(CASE WHEN order_total > 20 THEN 1 END)
+
+    """
+    return {
+        "expression": convert_query_to_projection(sql, dialect),
+        "metric_name": name,
+        "metric_type": metric_type,
+        "verbose_name": name,
+        "description": description,
+    }
+
+
+class MultipleModelsError(Exception):
+    """
+    Raised when a metric depends on multiple models.
+    """
+
+
+def get_model_from_sql(
+    sql: str,
+    dialect: str,
+    model_map: Dict[ModelKey, ModelSchema],
+) -> ModelSchema:
+    """
+    Return the model associated with a SQL query.
+    """
+    parsed_query = parse_one(sql, dialect=DIALECT_MAP.get(dialect))
+    sources = list(parsed_query.find_all(Table))
+    if len(sources) > 1:
+        raise MultipleModelsError(
+            f"Unable to convert metrics with multiple sources: {sql}"
+        )
+
+    table = sources[0]
+    key = ModelKey(table.db, table.name)
+
+    return model_map[key]

--- a/src/preset_cli/cli/superset/sync/dbt/metrics.py
+++ b/src/preset_cli/cli/superset/sync/dbt/metrics.py
@@ -22,7 +22,7 @@ from preset_cli.api.clients.dbt import (
     FilterSchema,
     MetricSchema,
     MFMetricWithSQLSchema,
-    MFSQLEngineSchema,
+    MFSQLEngine,
     ModelSchema,
 )
 from preset_cli.api.clients.superset import SupersetMetricDefinition
@@ -32,12 +32,12 @@ _logger = logging.getLogger(__name__)
 
 # dbt => sqlglot
 DIALECT_MAP = {
-    MFSQLEngineSchema.BIGQUERY: "bigquery",
-    MFSQLEngineSchema.DUCKDB: "duckdb",
-    MFSQLEngineSchema.REDSHIFT: "redshift",
-    MFSQLEngineSchema.POSTGRES: "postgres",
-    MFSQLEngineSchema.SNOWFLAKE: "snowflake",
-    MFSQLEngineSchema.DATABRICKS: "databricks",
+    MFSQLEngine.BIGQUERY: "bigquery",
+    MFSQLEngine.DUCKDB: "duckdb",
+    MFSQLEngine.REDSHIFT: "redshift",
+    MFSQLEngine.POSTGRES: "postgres",
+    MFSQLEngine.SNOWFLAKE: "snowflake",
+    MFSQLEngine.DATABRICKS: "databricks",
 }
 
 
@@ -244,7 +244,7 @@ def extract_aliases(parsed_query: Expression) -> Dict[str, str]:
     return aliases
 
 
-def convert_query_to_projection(sql: str, dialect: str) -> str:
+def convert_query_to_projection(sql: str, dialect: MFSQLEngine) -> str:
     """
     Convert a MetricFlow compiled SQL to a projection.
     """
@@ -293,7 +293,7 @@ def convert_metric_flow_to_superset(
     description: str,
     metric_type: str,
     sql: str,
-    dialect: str,
+    dialect: MFSQLEngine,
 ) -> SupersetMetricDefinition:
     """
     Convert a MetricFlow metric to a Superset metric.
@@ -337,7 +337,7 @@ class MultipleModelsError(Exception):
 
 def get_model_from_sql(
     sql: str,
-    dialect: str,
+    dialect: MFSQLEngine,
     model_map: Dict[ModelKey, ModelSchema],
 ) -> ModelSchema:
     """
@@ -347,7 +347,7 @@ def get_model_from_sql(
     sources = list(parsed_query.find_all(Table))
     if len(sources) > 1:
         raise MultipleModelsError(
-            f"Unable to convert metrics with multiple sources: {sql}"
+            f"Unable to convert metrics with multiple sources: {sql}",
         )
 
     table = sources[0]

--- a/tests/api/clients/dbt_test.py
+++ b/tests/api/clients/dbt_test.py
@@ -1051,40 +1051,42 @@ def test_dbt_client_get_models(mocker: MockerFixture) -> None:
     GraphqlClient = mocker.patch("preset_cli.api.clients.dbt.GraphqlClient")
     GraphqlClient().execute.return_value = {
         "data": {
-            "models": [
-                {
-                    "uniqueId": "model.jaffle_shop.customers",
-                    "name": "customers",
-                    "database": "dbt-tutorial-347100",
-                    "schema": "dbt_beto",
-                    "description": "One record per customer",
-                    "meta": {"superset": {"cache_timeout": 600}},
-                },
-                {
-                    "uniqueId": "model.jaffle_shop.stg_customers",
-                    "name": "stg_customers",
-                    "database": "dbt-tutorial-347100",
-                    "schema": "dbt_beto",
-                    "description": "This model cleans up customer data",
-                    "meta": {},
-                },
-                {
-                    "uniqueId": "model.jaffle_shop.stg_orders",
-                    "name": "stg_orders",
-                    "database": "dbt-tutorial-347100",
-                    "schema": "dbt_beto",
-                    "description": "This model cleans up order data",
-                    "meta": {},
-                },
-                {
-                    "uniqueId": "model.metrics.dbt_metrics_default_calendar",
-                    "name": "dbt_metrics_default_calendar",
-                    "database": "dbt-tutorial-347100",
-                    "schema": "dbt_beto",
-                    "description": "",
-                    "meta": {},
-                },
-            ],
+            "job": {
+                "models": [
+                    {
+                        "uniqueId": "model.jaffle_shop.customers",
+                        "name": "customers",
+                        "database": "dbt-tutorial-347100",
+                        "schema": "dbt_beto",
+                        "description": "One record per customer",
+                        "meta": {"superset": {"cache_timeout": 600}},
+                    },
+                    {
+                        "uniqueId": "model.jaffle_shop.stg_customers",
+                        "name": "stg_customers",
+                        "database": "dbt-tutorial-347100",
+                        "schema": "dbt_beto",
+                        "description": "This model cleans up customer data",
+                        "meta": {},
+                    },
+                    {
+                        "uniqueId": "model.jaffle_shop.stg_orders",
+                        "name": "stg_orders",
+                        "database": "dbt-tutorial-347100",
+                        "schema": "dbt_beto",
+                        "description": "This model cleans up order data",
+                        "meta": {},
+                    },
+                    {
+                        "uniqueId": "model.metrics.dbt_metrics_default_calendar",
+                        "name": "dbt_metrics_default_calendar",
+                        "database": "dbt-tutorial-347100",
+                        "schema": "dbt_beto",
+                        "description": "",
+                        "meta": {},
+                    },
+                ],
+            },
         },
     }
     auth = Auth()
@@ -1173,40 +1175,42 @@ def test_dbt_client_get_database_name(mocker: MockerFixture) -> None:
     GraphqlClient = mocker.patch("preset_cli.api.clients.dbt.GraphqlClient")
     GraphqlClient().execute.return_value = {
         "data": {
-            "models": [
-                {
-                    "uniqueId": "model.jaffle_shop.customers",
-                    "name": "customers",
-                    "database": "dbt-tutorial-347100",
-                    "schema": "dbt_beto",
-                    "description": "One record per customer",
-                    "meta": {"superset": {"cache_timeout": 600}},
-                },
-                {
-                    "uniqueId": "model.jaffle_shop.stg_customers",
-                    "name": "stg_customers",
-                    "database": "dbt-tutorial-347100",
-                    "schema": "dbt_beto",
-                    "description": "This model cleans up customer data",
-                    "meta": {},
-                },
-                {
-                    "uniqueId": "model.jaffle_shop.stg_orders",
-                    "name": "stg_orders",
-                    "database": "dbt-tutorial-347100",
-                    "schema": "dbt_beto",
-                    "description": "This model cleans up order data",
-                    "meta": {},
-                },
-                {
-                    "uniqueId": "model.metrics.dbt_metrics_default_calendar",
-                    "name": "dbt_metrics_default_calendar",
-                    "database": "dbt-tutorial-347100",
-                    "schema": "dbt_beto",
-                    "description": "",
-                    "meta": {},
-                },
-            ],
+            "job": {
+                "models": [
+                    {
+                        "uniqueId": "model.jaffle_shop.customers",
+                        "name": "customers",
+                        "database": "dbt-tutorial-347100",
+                        "schema": "dbt_beto",
+                        "description": "One record per customer",
+                        "meta": {"superset": {"cache_timeout": 600}},
+                    },
+                    {
+                        "uniqueId": "model.jaffle_shop.stg_customers",
+                        "name": "stg_customers",
+                        "database": "dbt-tutorial-347100",
+                        "schema": "dbt_beto",
+                        "description": "This model cleans up customer data",
+                        "meta": {},
+                    },
+                    {
+                        "uniqueId": "model.jaffle_shop.stg_orders",
+                        "name": "stg_orders",
+                        "database": "dbt-tutorial-347100",
+                        "schema": "dbt_beto",
+                        "description": "This model cleans up order data",
+                        "meta": {},
+                    },
+                    {
+                        "uniqueId": "model.metrics.dbt_metrics_default_calendar",
+                        "name": "dbt_metrics_default_calendar",
+                        "database": "dbt-tutorial-347100",
+                        "schema": "dbt_beto",
+                        "description": "",
+                        "meta": {},
+                    },
+                ],
+            },
         },
     }
     auth = Auth()
@@ -1219,7 +1223,7 @@ def test_dbt_client_get_database_name_no_models(mocker: MockerFixture) -> None:
     Test the ``get_database_name`` method when there are no models.
     """
     GraphqlClient = mocker.patch("preset_cli.api.clients.dbt.GraphqlClient")
-    GraphqlClient().execute.return_value = {"data": {"models": []}}
+    GraphqlClient().execute.return_value = {"data": {"job": {"models": []}}}
     auth = Auth()
     client = DBTClient(auth)
 
@@ -1237,24 +1241,26 @@ def test_dbt_client_get_database_name_multiple(mocker: MockerFixture) -> None:
     GraphqlClient = mocker.patch("preset_cli.api.clients.dbt.GraphqlClient")
     GraphqlClient().execute.return_value = {
         "data": {
-            "models": [
-                {
-                    "uniqueId": "model.jaffle_shop.customers",
-                    "name": "customers",
-                    "database": "database_two",
-                    "schema": "dbt_beto",
-                    "description": "One record per customer",
-                    "meta": {"superset": {"cache_timeout": 600}},
-                },
-                {
-                    "uniqueId": "model.jaffle_shop.stg_customers",
-                    "name": "stg_customers",
-                    "database": "database_one",
-                    "schema": "dbt_beto",
-                    "description": "This model cleans up customer data",
-                    "meta": {},
-                },
-            ],
+            "job": {
+                "models": [
+                    {
+                        "uniqueId": "model.jaffle_shop.customers",
+                        "name": "customers",
+                        "database": "database_two",
+                        "schema": "dbt_beto",
+                        "description": "One record per customer",
+                        "meta": {"superset": {"cache_timeout": 600}},
+                    },
+                    {
+                        "uniqueId": "model.jaffle_shop.stg_customers",
+                        "name": "stg_customers",
+                        "database": "database_one",
+                        "schema": "dbt_beto",
+                        "description": "This model cleans up customer data",
+                        "meta": {},
+                    },
+                ],
+            },
         },
     }
     auth = Auth()

--- a/tests/api/clients/dbt_test.py
+++ b/tests/api/clients/dbt_test.py
@@ -37,33 +37,6 @@ def test_postel_enum_field() -> None:
     assert isinstance(PostelEnumField(RawEnum), fields.Raw)
 
 
-def test_dbt_client_execute(mocker: MockerFixture) -> None:
-    """
-    Test the ``execute`` method.
-    """
-    GraphqlClient = mocker.patch("preset_cli.api.clients.dbt.GraphqlClient")
-    auth = Auth()
-    client = DBTClient(auth)
-    query = """
-        query ($jobId: Int!) {
-            models(jobId: $jobId) {
-                uniqueId
-                name
-                database
-                schema
-                description
-                meta
-            }
-        }
-    """
-    client.execute(query, jobId=1)
-    GraphqlClient().execute.assert_called_with(
-        query=query,
-        variables={"jobId": 1},
-        headers=client.session.headers,
-    )
-
-
 def test_dbt_client_get_accounts(requests_mock: Mocker) -> None:
     """
     Test the ``get_accounts`` method.

--- a/tests/cli/superset/sync/dbt/command_test.py
+++ b/tests/cli/superset/sync/dbt/command_test.py
@@ -13,6 +13,7 @@ from click.testing import CliRunner
 from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest_mock import MockerFixture
 
+from preset_cli.api.clients.dbt import MFSQLEngine
 from preset_cli.cli.superset.main import superset_cli
 from preset_cli.cli.superset.sync.dbt.command import (
     get_account_id,
@@ -970,7 +971,7 @@ def test_dbt_cloud(mocker: MockerFixture) -> None:
 
     dbt_client.get_models.return_value = dbt_cloud_models
     dbt_client.get_og_metrics.return_value = dbt_cloud_metrics
-    dbt_client.get_sl_dialect.return_value = "BIGQUERY"
+    dbt_client.get_sl_dialect.return_value = MFSQLEngine.BIGQUERY
     dbt_client.get_sl_metrics.return_value = dbt_metricflow_metrics
     dbt_client.get_sl_metric_sql.side_effect = [
         "SELECT COUNT(*) FROM public.messages_channels",

--- a/tests/cli/superset/sync/dbt/exposures_test.py
+++ b/tests/cli/superset/sync/dbt/exposures_test.py
@@ -758,7 +758,7 @@ def test_get_chart_depends_on_from_dataset(mocker: MockerFixture) -> None:
     depends_on = get_chart_depends_on(
         client,
         chart_response["result"],
-        {key: "ref('messages_channels')"},
+        {key: {"name": "messages_channels"}},  # type: ignore
     )
     assert depends_on == ["ref('messages_channels')"]
 
@@ -798,6 +798,6 @@ def test_get_dashboard_depends_on_from_dataset(mocker: MockerFixture) -> None:
     depends_on = get_dashboard_depends_on(
         client,
         dashboard_response["result"],
-        {key: "ref('messages_channels')"},
+        {key: {"name": "messages_channels"}},  # type: ignore
     )
     assert depends_on == ["ref('messages_channels')"]

--- a/tests/cli/superset/sync/dbt/metrics_test.py
+++ b/tests/cli/superset/sync/dbt/metrics_test.py
@@ -9,7 +9,7 @@ from typing import Dict
 import pytest
 from pytest_mock import MockerFixture
 
-from preset_cli.api.clients.dbt import MetricSchema
+from preset_cli.api.clients.dbt import MetricSchema, MFSQLEngine
 from preset_cli.cli.superset.sync.dbt.metrics import (
     convert_query_to_projection,
     get_metric_expression,
@@ -423,7 +423,7 @@ def test_convert_query_to_projection() -> None:
                 SELECT COUNT(DISTINCT customer_id) AS customers_with_orders
                 FROM `dbt-tutorial-347100`.`dbt_beto`.`orders` orders_src_96
             """,
-            "BIGQUERY",
+            MFSQLEngine.BIGQUERY,
         )
         == "COUNT(DISTINCT customer_id)"
     )
@@ -443,7 +443,7 @@ def test_convert_query_to_projection() -> None:
                 ) subq_423
                 WHERE customer__customer_type  = 'new'
             """,
-            "BIGQUERY",
+            MFSQLEngine.BIGQUERY,
         )
     assert str(excinfo.value) == "Unable to convert metrics with JOINs"
 
@@ -454,7 +454,7 @@ def test_convert_query_to_projection() -> None:
                     SUM(order_total) AS order_total
                 FROM `dbt-tutorial-347100`.`dbt_beto`.`orders` orders_src_141
             """,
-            "BIGQUERY",
+            MFSQLEngine.BIGQUERY,
         )
         == "SUM(order_total)"
     )
@@ -471,7 +471,7 @@ FROM (
   FROM `dbt-tutorial-347100`.`dbt_beto`.`orders` orders_src_106
 ) subq_796
             """,
-            "BIGQUERY",
+            MFSQLEngine.BIGQUERY,
         )
         == "SUM(1)"
     )
@@ -489,7 +489,7 @@ FROM (
 ) subq_796
 WHERE order_id__order_total_dim >= 20
             """,
-            "BIGQUERY",
+            MFSQLEngine.BIGQUERY,
         )
         == "SUM(CASE WHEN order_total >= 20 THEN 1 END)"
     )
@@ -501,7 +501,7 @@ WHERE order_id__order_total_dim >= 20
                     SUM(1) AS orders
                 FROM `dbt-tutorial-347100`.`dbt_beto`.`orders` orders_src_143
             """,
-            "BIGQUERY",
+            MFSQLEngine.BIGQUERY,
         )
         == "SUM(1)"
     )
@@ -519,7 +519,7 @@ WHERE order_id__order_total_dim >= 20
                 ) subq_549
                 WHERE order_id__is_food_order = true
             """,
-            "BIGQUERY",
+            MFSQLEngine.BIGQUERY,
         )
         == "SUM(CASE WHEN is_food_order = TRUE THEN 1 END)"
     )
@@ -531,7 +531,7 @@ WHERE order_id__order_total_dim >= 20
                     SUM(product_price) AS revenue
                 FROM `dbt-tutorial-347100`.`dbt_beto`.`order_items` order_item_src_111
             """,
-            "BIGQUERY",
+            MFSQLEngine.BIGQUERY,
         )
         == "SUM(product_price)"
     )
@@ -543,7 +543,7 @@ WHERE order_id__order_total_dim >= 20
                     SUM(order_cost) AS order_cost
                 FROM `dbt-tutorial-347100`.`dbt_beto`.`orders` orders_src_99
             """,
-            "BIGQUERY",
+            MFSQLEngine.BIGQUERY,
         )
         == "SUM(order_cost)"
     )
@@ -555,7 +555,7 @@ WHERE order_id__order_total_dim >= 20
                     SUM(case when is_food_item = 1 then product_price else 0 end) AS food_revenue
                 FROM `dbt-tutorial-347100`.`dbt_beto`.`order_items` order_item_src_140
             """,
-            "BIGQUERY",
+            MFSQLEngine.BIGQUERY,
         )
         == "SUM(CASE WHEN is_food_item = 1 THEN product_price ELSE 0 END)"
     )
@@ -567,7 +567,7 @@ WHERE order_id__order_total_dim >= 20
                     CAST(SUM(case when is_food_item = 1 then product_price else 0 end) AS FLOAT64) / CAST(NULLIF(SUM(product_price), 0) AS FLOAT64) AS food_revenue_pct
                 FROM `dbt-tutorial-347100`.`dbt_beto`.`order_items` order_item_src_98
             """,
-            "BIGQUERY",
+            MFSQLEngine.BIGQUERY,
         )
         == "CAST(SUM(CASE WHEN is_food_item = 1 THEN product_price ELSE 0 END) AS DOUBLE) / CAST(NULLIF(SUM(product_price), 0) AS DOUBLE)"
     )
@@ -593,7 +593,7 @@ WHERE order_id__order_total_dim >= 20
                     ) subq_570
                 ) subq_571
             """,
-            "BIGQUERY",
+            MFSQLEngine.BIGQUERY,
         )
     assert str(excinfo.value) == "Unable to convert metrics with JOINs"
 
@@ -604,7 +604,7 @@ WHERE order_id__order_total_dim >= 20
                     SUM(product_price) AS cumulative_revenue
                 FROM `dbt-tutorial-347100`.`dbt_beto`.`order_items` order_item_src_114
             """,
-            "BIGQUERY",
+            MFSQLEngine.BIGQUERY,
         )
         == "SUM(product_price)"
     )


### PR DESCRIPTION
This PR introduces an algorithm for syncing dbt metrics defined using [MetricFlow](https://docs.getdbt.com/docs/build/sl-getting-started). In order to sync metrics it:

1. Queries a new GraphQL endpoint to get all the names of the metrics
2. Queries a new GraphQL endpoint to get the SQL for each of the metrics
3. Converts the SQL (a full query) into a projection, using an algorithm similar to the one used with older metrics

Because in MetricFlow metrics are a higher concept, not all metrics can be converted. For example, a metric could be "sales in France", having an implicit `JOIN` in them. Metrics with joins and/or multiple tables are ignored, and the error is logged.

Note that MetricFlow has a concept called "measure" which is much closer to the Superset metric. Unfortunately the GraphQL API doesn't expose all the information we need about measures to convert them into Superset metrics. Namely, the models to which each measure belong are not available via the API.

Testing:

```bash
$ preset-cli --workspaces=https://b5eda41a.us1a.app.preset.io/ superset sync dbt-cloud dbtc_XXX 485502
```

Models and metrics are synced correctly to: https://b5eda41a.us1a.app.preset.io/tablemodelview/list/?pageIndex=0&sortColumn=changed_on_delta_humanized&sortOrder=desc