### PR TITLE
feat(dbt): allow passing custom URL

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -11,6 +11,7 @@ References:
 # pylint: disable=invalid-name, too-few-public-methods
 
 import logging
+import re
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type, TypedDict
 
@@ -642,18 +643,71 @@ class DataResponse(TypedDict):
     data: Dict[str, Any]
 
 
+def get_custom_urls(access_url: Optional[str] = None) -> Dict[str, URL]:
+    """
+    Return new custom URLs for dbt Cloud access.
+    """
+    if access_url is None:
+        return {
+            "admin": REST_ENDPOINT,
+            "discovery": METADATA_GRAPHQL_ENDPOINT,
+            "semantic-layer": SEMANTIC_LAYER_GRAPHQL_ENDPOINT,
+        }
+
+    regex_pattern = r"""
+        (?P<code>
+            [a-zA-Z0-9]
+            (?:
+                [a-zA-Z0-9-]{0,61}
+                [a-zA-Z0-9]
+            )?
+        )
+        \.
+        (?P<region>
+            [a-zA-Z0-9]
+            (?:
+                [a-zA-Z0-9-]{0,61}
+                [a-zA-Z0-9]
+            )?
+        )
+        \.
+        (?P<domain>
+            (?:get)?    # Docs are not clear if we should dbt.com
+            dbt\.com    # or getdbt.com
+        )
+        $
+    """
+
+    parsed = URL(access_url)
+    if match := re.match(regex_pattern, parsed.host, re.VERBOSE):
+        return {
+            "admin": parsed.with_host(
+                f"{match['code']}.{match['region']}.{match['domain']}",
+            ),
+            "discovery": parsed.with_host(
+                f"{match['code']}.metadata.{match['region']}.{match['domain']}",
+            ),
+            "semantic-layer": parsed.with_host(
+                f"{match['code']}.semantic-layer.{match['region']}.{match['domain']}",
+            ),
+        }
+
+    raise Exception("Invalid host in custom URL")
+
+
 class DBTClient:  # pylint: disable=too-few-public-methods
 
     """
     A client for the dbt API.
     """
 
-    def __init__(self, auth: Auth):
-        self.metadata_graphql_client = GraphqlClient(endpoint=METADATA_GRAPHQL_ENDPOINT)
+    def __init__(self, auth: Auth, access_url: Optional[str] = None):
+        urls = get_custom_urls(access_url)
+        self.metadata_graphql_client = GraphqlClient(endpoint=urls["discovery"])
         self.semantic_layer_graphql_client = GraphqlClient(
-            endpoint=SEMANTIC_LAYER_GRAPHQL_ENDPOINT,
+            endpoint=urls["semantic-layer"],
         )
-        self.baseurl = REST_ENDPOINT
+        self.baseurl = urls["admin"]
 
         self.session = auth.session
         self.session.headers.update(auth.get_headers())

--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -670,11 +670,7 @@ def get_custom_urls(access_url: Optional[str] = None) -> Dict[str, URL]:
                 [a-zA-Z0-9]
             )?
         )
-        \.
-        (?P<domain>
-            (?:get)?    # Docs are not clear if we should dbt.com
-            dbt\.com    # or getdbt.com
-        )
+        \.dbt.com
         $
     """
 
@@ -682,13 +678,13 @@ def get_custom_urls(access_url: Optional[str] = None) -> Dict[str, URL]:
     if match := re.match(regex_pattern, parsed.host, re.VERBOSE):
         return {
             "admin": parsed.with_host(
-                f"{match['code']}.{match['region']}.{match['domain']}",
+                f"{match['code']}.{match['region']}.dbt.com",
             ),
             "discovery": parsed.with_host(
-                f"{match['code']}.metadata.{match['region']}.{match['domain']}",
+                f"{match['code']}.metadata.{match['region']}.dbt.com",
             ),
             "semantic-layer": parsed.with_host(
-                f"{match['code']}.semantic-layer.{match['region']}.{match['domain']}",
+                f"{match['code']}.semantic-layer.{match['region']}.dbt.com",
             ),
         }
 

--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -422,6 +422,10 @@ def process_sl_metrics(
     default=False,
     help="Update Preset configurations based on dbt metadata. Preset-only metrics are preserved",
 )
+@click.option(
+    "--access-url",
+    help="Custom API URL for dbt Cloud (eg, https://ab123.us1.dbt.com)",
+)
 @click.pass_context
 def dbt_cloud(  # pylint: disable=too-many-arguments, too-many-locals
     ctx: click.core.Context,
@@ -436,6 +440,7 @@ def dbt_cloud(  # pylint: disable=too-many-arguments, too-many-locals
     preserve_columns: bool = False,
     preserve_metadata: bool = False,
     merge_metadata: bool = False,
+    access_url: Optional[str] = None,
 ) -> None:
     """
     Sync models/metrics from dbt Cloud to Superset.
@@ -445,7 +450,7 @@ def dbt_cloud(  # pylint: disable=too-many-arguments, too-many-locals
     superset_client = SupersetClient(url, superset_auth)
 
     dbt_auth = TokenAuth(token)
-    dbt_client = DBTClient(dbt_auth)
+    dbt_client = DBTClient(dbt_auth, access_url)
 
     if (preserve_columns or preserve_metadata) and merge_metadata:
         click.echo(


### PR DESCRIPTION
Add support for passing a custom access URL for the dbt APIs. This will be needed later this year, see https://docs.google.com/document/d/1oiyACMtQaxlbp90LKIh3EyUqBnzZM5NfuTW25fWhDA0/edit.

Ticket: https://app.shortcut.com/preset/story/78260/dbt-update-ui-to-ask-for-urls