### PR TITLE
feat(dbt): Adding flag to raise an error when a model sync fails

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -198,8 +198,8 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-branches, too-many
             models.append(model_schema.load(config))
     models = apply_select(models, select, exclude)
     model_map = {ModelKey(model["schema"], model["name"]): model for model in models}
-    
-    failures = []
+
+    failures: List[str] = []
 
     if exposures_only:
         datasets = [
@@ -247,7 +247,7 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-branches, too-many
     if exposures:
         exposures = os.path.expanduser(exposures)
         sync_exposures(client, Path(exposures), datasets, model_map)
-    
+
     if failures and raise_failures:
         list_failed_models(failures)
 
@@ -520,7 +520,7 @@ def dbt_cloud(  # pylint: disable=too-many-arguments, too-many-locals
     sl_metrics = process_sl_metrics(dbt_client, job["environment_id"], model_map)
     superset_metrics = get_superset_metrics_per_model(og_metrics, sl_metrics)
 
-    failures = []
+    failures: List[str] = []
 
     if exposures_only:
         datasets = [

--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -178,7 +178,9 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-branches, too-ma
             fragment = "!/model/{unique_id}".format(**model)
             update["external_url"] = str(base_url.with_fragment(fragment))
         try:
-            client.update_dataset(dataset["id"], override_columns=reload_columns, **update)
+            client.update_dataset(
+                dataset["id"], override_columns=reload_columns, **update
+            )
         except SupersetError:
             failed_datasets.append(model["unique_id"])
             continue

--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -7,9 +7,11 @@ import json
 import logging
 import os
 import re
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union
 
+import click
 import yaml
 from jinja2 import Environment
 from sqlalchemy.engine.url import URL
@@ -459,3 +461,19 @@ def apply_select(
                 del selected[id_]
 
     return list(selected.values())
+
+def list_failed_models(failed_models: List[str]) -> None:
+    """
+    List models that failed to sync and ends execution with an error code
+    """
+    error_message = "Below model(s) failed to sync:"
+    for failed_model in failed_models:
+        error_message += f"\n - {failed_model}"
+
+    click.echo(
+        click.style(
+            error_message,
+            fg="bright_red",
+        ),
+    )
+    sys.exit(1)

--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -462,6 +462,7 @@ def apply_select(
 
     return list(selected.values())
 
+
 def list_failed_models(failed_models: List[str]) -> None:
     """
     List models that failed to sync and ends execution with an error code

--- a/tests/cli/superset/sync/dbt/lib_test.py
+++ b/tests/cli/superset/sync/dbt/lib_test.py
@@ -621,6 +621,7 @@ def test_apply_select_using_path(fs: FakeFilesystem) -> None:
         "three",
     }
 
+
 def test_list_failed_models_single_model(capsys) -> None:
     """
     Test ``list_failed_models()`` with a single failed model
@@ -630,10 +631,11 @@ def test_list_failed_models_single_model(capsys) -> None:
 
     captured = capsys.readouterr()
     expected_output = "Below model(s) failed to sync:\n - single_failure\n"
-    
+
     assert captured.out == expected_output
     assert excinfo.type == SystemExit
     assert excinfo.value.code == 1
+
 
 def test_list_failed_models_multiple_models(capsys) -> None:
     """
@@ -643,8 +645,10 @@ def test_list_failed_models_multiple_models(capsys) -> None:
         list_failed_models(["single_failure", "another_failure"])
 
     captured = capsys.readouterr()
-    expected_output = "Below model(s) failed to sync:\n - single_failure\n - another_failure\n"
-    
+    expected_output = (
+        "Below model(s) failed to sync:\n - single_failure\n - another_failure\n"
+    )
+
     assert captured.out == expected_output
     assert excinfo.type == SystemExit
     assert excinfo.value.code == 1

--- a/tests/cli/superset/sync/dbt/lib_test.py
+++ b/tests/cli/superset/sync/dbt/lib_test.py
@@ -19,6 +19,7 @@ from preset_cli.cli.superset.sync.dbt.lib import (
     build_sqlalchemy_params,
     env_var,
     filter_models,
+    list_failed_models,
     load_profiles,
 )
 
@@ -619,3 +620,31 @@ def test_apply_select_using_path(fs: FakeFilesystem) -> None:
         "two",
         "three",
     }
+
+def test_list_failed_models_single_model(capsys) -> None:
+    """
+    Test ``list_failed_models()`` with a single failed model
+    """
+    with pytest.raises(SystemExit) as excinfo:
+        list_failed_models(["single_failure"])
+
+    captured = capsys.readouterr()
+    expected_output = "Below model(s) failed to sync:\n - single_failure\n"
+    
+    assert captured.out == expected_output
+    assert excinfo.type == SystemExit
+    assert excinfo.value.code == 1
+
+def test_list_failed_models_multiple_models(capsys) -> None:
+    """
+    Test ``list_failed_models()`` with multipled failed models
+    """
+    with pytest.raises(SystemExit) as excinfo:
+        list_failed_models(["single_failure", "another_failure"])
+
+    captured = capsys.readouterr()
+    expected_output = "Below model(s) failed to sync:\n - single_failure\n - another_failure\n"
+    
+    assert captured.out == expected_output
+    assert excinfo.type == SystemExit
+    assert excinfo.value.code == 1


### PR DESCRIPTION
Currently, during the dbt sync models might fail to be synced. The operation is not atomic (a sync failure won't prevent other models from being synced) and the CLI logs the error messages. 

While the error messages are helpful to debug the issue, when using the CLI in a CI/CD pipeline, the fact that the execution ends up successfully would show the job in a successful state, which could be misleading since there were issues. 

This PR adds a new flag `--raise-failures` that when used would end the command execution with an error status code in case any model failed to sync. 