### PR TITLE
fix(dbt): Support syncing derived metrics on legacy dbt versions

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -589,6 +589,7 @@ class MetricSchema(PostelSchema):
     # dbt >= 1.3
     calculation_method = fields.String()
     expression = fields.String()
+    dialect = fields.String()
 
 
 class MFMetricType(str, Enum):

--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -184,7 +184,8 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-branches, too-many
 
     with open(profiles, encoding="utf-8") as input_:
         config = yaml.safe_load(input_)
-    dialect = MFSQLEngine(config[project]["outputs"][target]["type"].upper())
+    dialect = config[project]["outputs"][target]["type"]
+    mf_dialect = MFSQLEngine(dialect.upper())
 
     model_schema = ModelSchema()
     models = []
@@ -215,8 +216,9 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-branches, too-many
                 # conform to the same schema that dbt Cloud uses for metrics
                 config["dependsOn"] = config.pop("depends_on")["nodes"]
                 config["uniqueId"] = config.pop("unique_id")
+                config["dialect"] = dialect
                 og_metrics.append(metric_schema.load(config))
-            elif sl_metric := get_sl_metric(config, model_map, dialect):
+            elif sl_metric := get_sl_metric(config, model_map, mf_dialect):
                 sl_metrics.append(sl_metric)
 
         superset_metrics = get_superset_metrics_per_model(og_metrics, sl_metrics)


### PR DESCRIPTION
[PR#254](https://github.com/preset-io/backend-sdk/pull/254/files#diff-6a9da321f6c92c5e31f999ebd04d4f2f1c0dceb066d3aae0d59cc836eb2444b4R157-R164) introduced a new pattern for mapping metrics:

``` python
metric_map = {metric["unique_id"]: metric for metric in metrics}
```

This ended up affecting our ability to parse derived metrics, given the metric macro renders the metric `name`, rather than its `unique_id`. As a consequence, [this condition](https://github.com/preset-io/backend-sdk/pull/255/files#diff-6a9da321f6c92c5e31f999ebd04d4f2f1c0dceb066d3aae0d59cc836eb2444b4R81-R82) was never met (since `token.sql()` would return the macro name):

``` python
for token in tokens:
      if token.sql() in metrics:
```

This section of the code is only used by legacy dbt versions -- for new versions we're relying on `MetricFlow` to provide the metric syntax.

This PR re-introduces the old mapping structure specifically for this context:
``` python
metric_map = {metric["name"]: metric for metric in metrics}
```

It also includes the `dialect` as part of the metric schema, to assist `sqlglot` when parsing the syntax. I was facing an issue when trying to parse below metric syntax since it's BQ-specific:
``` sql
SAFE_DIVIDE(
   SUM(
      IF(
         `product_line` = "Classic Cars",
         price_each * 0.80,
         price_each * 0.70
      )
   ),
   revenue_verbose_name_from_dbt
)
```