### PR TITLE
fix(sqlglot): Convert metric syntax back to dialect-specific after parsing it

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/metrics.py
+++ b/src/preset_cli/cli/superset/sync/dbt/metrics.py
@@ -89,7 +89,7 @@ def get_metric_expression(metric_name: str, metrics: Dict[str, MetricSchema]) ->
                 )
                 token.replace(parent_expression)
 
-        return expression.sql()
+        return expression.sql(dialect=metric["dialect"])
 
     sorted_metric = dict(sorted(metric.items()))
     raise Exception(f"Unable to generate metric expression from: {sorted_metric}")
@@ -285,7 +285,7 @@ def convert_query_to_projection(sql: str, dialect: MFSQLEngine) -> str:
         )
         metric_expression.set("this", case_expression)
 
-    return metric_expression.sql()
+    return metric_expression.sql(dialect=DIALECT_MAP.get(dialect))
 
 
 def convert_metric_flow_to_superset(

--- a/tests/cli/superset/sync/dbt/metrics_test.py
+++ b/tests/cli/superset/sync/dbt/metrics_test.py
@@ -238,7 +238,7 @@ SAFE_DIVIDE(
     result = get_metric_expression(unique_id, metrics)
     assert (
         result
-        == "SAFE_DIVIDE(SUM(CASE WHEN \"product_line\" = 'Classic Cars' THEN price_each * 0.80 ELSE price_each * 0.70 END), SUM(price_each))"
+        == "SAFE_DIVIDE(SUM(IF(`product_line` = 'Classic Cars', price_each * 0.80, price_each * 0.70)), SUM(price_each))"
     )
 
 
@@ -683,7 +683,19 @@ WHERE order_id__order_total_dim >= 20
             """,
             MFSQLEngine.BIGQUERY,
         )
-        == "CAST(SUM(CASE WHEN is_food_item = 1 THEN product_price ELSE 0 END) AS DOUBLE) / CAST(NULLIF(SUM(product_price), 0) AS DOUBLE)"
+        == "CAST(SUM(CASE WHEN is_food_item = 1 THEN product_price ELSE 0 END) AS FLOAT64) / CAST(NULLIF(SUM(product_price), 0) AS FLOAT64)"
+    )
+
+    assert (
+        convert_query_to_projection(
+            """
+                SELECT
+                    AVG(DATE_DIFF(start_date, end_date, DAY)) AS avg_time_diff
+                FROM `dbt-tutorial-347100`.`dbt_beto`.`order_items` order_item_src_98
+            """,
+            MFSQLEngine.BIGQUERY,
+        )
+        == "AVG(DATE_DIFF(start_date, end_date, DAY))"
     )
 
     with pytest.raises(ValueError) as excinfo:


### PR DESCRIPTION
The CLI uses `sqlglot` to parse SQL syntax from dbt metrics. While we were specifying the SQL dialect when parsing the query, we were not specifying the dialect when converting the parsed result back to SQL, which would cause issues with engine-specific syntaxes. Some examples:
* A BQ metric created using `IF()` statement would get converted to `CASE` (would still work but different syntax)
* A BQ metric created using `DATE_DIFF()` would get converted to `DATEDIFF()` which doesn't work with BQ.