### PR TITLE
fix(dbt): Support filtered COUNT DISTINCT in metrics

### DIFF
--- a/tests/cli/superset/sync/dbt/metrics_test.py
+++ b/tests/cli/superset/sync/dbt/metrics_test.py
@@ -698,6 +698,24 @@ WHERE order_id__order_total_dim >= 20
         == "AVG(DATE_DIFF(start_date, end_date, DAY))"
     )
 
+    assert (
+        convert_query_to_projection(
+            """
+                SELECT
+                    COUNT(DISTINCT distinct_count_test) AS test_distinct_metric
+                FROM (
+                    SELECT
+                        quantity AS id__quantity
+                        , id AS distinct_count_test
+                    FROM `dbt-tutorial-347100`.`dbt_beto`.`distinct_test` distinct_test_src_10000
+                ) subq_2
+                WHERE id__quantity > 10
+            """,
+            MFSQLEngine.BIGQUERY,
+        )
+        == "COUNT(DISTINCT CASE WHEN quantity > 10 THEN id END)"
+    )
+
     with pytest.raises(ValueError) as excinfo:
         convert_query_to_projection(
             """


### PR DESCRIPTION
When creating a `COUNT (DISTINCT x)` metric with a filter -- for example:
``` yaml
semantic_models:
  - name: datadiff_test
    ...
    measures:
      - name: distinct_count_test
        expr: id
        description: "The count of unique rows."
        agg: count_distinct
    dimensions:
      - name: quantity
        type: categorical
    ...

metrics:
  - name: test_distinct_metric
    description: "The number of unique rows."
    type: simple
    label: Number of CX Sent Secure Messages
    type_params:
      measure: distinct_count_test
    filter: |                                     
      {{  Dimension('id__quantity') }} > 10
```

The metric conversion would result in an incompatible syntax:
``` sql
COUNT(CASE WHEN quantity > 10 THEN DISTINCT id END)
```

This PR updates the logic to replace the `DISTINCT` as needed:
``` sql
COUNT(DISTINCT CASE WHEN quantity > 10 THEN id END)
```