### PR TITLE
fix(dbt): Dataset creation returns a different schema

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -111,7 +111,7 @@ def get_or_create_dataset(
     _logger.info("Creating dataset %s", model["unique_id"])
     try:
         dataset = create_dataset(client, database, model)
-        return dataset
+        return client.get_dataset(dataset["id"])
     except Exception as excinfo:
         _logger.exception("Unable to create dataset")
         raise CLIError("Unable to create dataset", 1) from excinfo


### PR DESCRIPTION
The response payload for ``create_dataset()`` is different than the one for ``client.get_dataset()``. This was causing an error as the actual dataset data (`metrics`, `columns`, etc) was nested under `data` for the creation command.

I could change the `return` statement to `dataset["data"]` (to avoid firing another API call) but I believe this way is easier to maintain in the long-term (otherwise we'll be exposed to issues when either of these two schema changes, and they could differ over time).

