### PR TITLE
fix(dbt-derived-metrics): Support raw metrics and Jinja syntax

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -590,6 +590,7 @@ class MetricSchema(PostelSchema):
     calculation_method = fields.String()
     expression = fields.String()
     dialect = fields.String()
+    skip_parsing = fields.Boolean(allow_none=True)
 
 
 class MFMetricType(str, Enum):

--- a/src/preset_cli/cli/superset/sync/dbt/metrics.py
+++ b/src/preset_cli/cli/superset/sync/dbt/metrics.py
@@ -93,11 +93,11 @@ def get_metric_expression(metric_name: str, metrics: Dict[str, MetricSchema]) ->
             expression = sqlglot.parse_one(sql, dialect=metric["dialect"])
         except ParseError:
             for parent_metric in metric["depends_on"]:
-                metric_name = parent_metric.split(".")[-1]
-                pattern = r"\b" + re.escape(metric_name) + r"\b"
-                parent_metric_syntax = get_metric_expression(metric_name, metrics)
+                parent_metric_name = parent_metric.split(".")[-1]
+                pattern = r"\b" + re.escape(parent_metric_name) + r"\b"
+                parent_metric_syntax = get_metric_expression(parent_metric_name, metrics)
                 sql = re.sub(pattern, parent_metric_syntax, sql)
-                return sql
+            return sql
 
         tokens = expression.find_all(exp.Column)
 

--- a/src/preset_cli/cli/superset/sync/dbt/metrics.py
+++ b/src/preset_cli/cli/superset/sync/dbt/metrics.py
@@ -50,6 +50,7 @@ DIALECT_MAP = {
 }
 
 
+# pylint: disable=too-many-locals
 def get_metric_expression(metric_name: str, metrics: Dict[str, MetricSchema]) -> str:
     """
     Return a SQL expression for a given dbt metric using sqlglot.

--- a/src/preset_cli/cli/superset/sync/dbt/metrics.py
+++ b/src/preset_cli/cli/superset/sync/dbt/metrics.py
@@ -95,7 +95,10 @@ def get_metric_expression(metric_name: str, metrics: Dict[str, MetricSchema]) ->
             for parent_metric in metric["depends_on"]:
                 parent_metric_name = parent_metric.split(".")[-1]
                 pattern = r"\b" + re.escape(parent_metric_name) + r"\b"
-                parent_metric_syntax = get_metric_expression(parent_metric_name, metrics)
+                parent_metric_syntax = get_metric_expression(
+                    parent_metric_name,
+                    metrics,
+                )
                 sql = re.sub(pattern, parent_metric_syntax, sql)
             return sql
 


### PR DESCRIPTION
dbt allows the creation of derived metrics with just raw SQL, not involving any other dbt metric:
``` yaml
metrics:
  - name: new_derived_again
    label: test
    calculation_method: derived
    expression: |
      {% raw %}
       (SUM(price_each)) * 1.2
      {% endraw %}
```

These would currently fail to sync, as derived metrics don't have a `model` definition, so currently the CLI identifies the desired model by getting the models used by the metrics used in the syntax (which don't exist in this case).

To support this flow, the CLI now will get the model's `unique_id` from `meta.superset.model` for such metrics:
``` yaml
metrics:
  - name: new_derived_again
    label: test
    calculation_method: derived
    expression: |
      {% raw %}
       (SUM(price_each)) * 1.2
      {% endraw %}
    meta:
      superset:
        model: model.postgres.vehicle_sales
```

the `{% raw %}` macro also allows users to use Superset-specific Jinja in their metrics:
``` yaml
metrics:
  - name: new_derived_again
    label: test
    calculation_method: derived
    expression: |
      {% raw %}
        SUM(
          {% for x in filter_values('x_values') %}
            {{ + x_values }}
          {% endfor %}
        )
      {% endraw %}
    meta:
      superset:
        model: model.postgres.vehicle_sales
  - name: new_derived
    label: test
    calculation_method: derived
    expression: |
      {% raw %}
        SUM(
          {% for x in filter_values('x_values') %}
            {{ + 
      {% endraw %}
              {{ metric('revenue_verbose_name_from_dbt')}}
      {% raw %}
            }}
          {% endfor %}
        )
      {% endraw %}
```

These were currently failing as we rely on `sqlglot` to parse the derived metrics and replace a metric `name` with its sql syntax. This PR changes the logic so that the SQL parsing is skipped in case the derived metric doesn't really include other metrics. In case it's a combination of Superset-Jinja + dbt Jinja (like the second example), the CLI will catch the `ParseError` exception and will perform a replace with regex for the metric (definitely not as stable as SQL parsing, but hoping to increase compatibility with these types of metrics).


These changes are currently aiming older versions of dbt -- going to also perform some tests with `MetricFlow`/new semantic layer to validate if these flows are supported in newer versions, to assess how to also support them with the CLI.