### PR TITLE
fix(dbt): Removing BQ-specific metadata from columns

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -46,6 +46,9 @@ def clean_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
         "name",
         "nullable",
         "type_generic",
+        "precision",
+        "scale",
+        "max_length",
     ):
         if key in metadata:
             del metadata[key]

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -1391,6 +1391,9 @@ def test_clean_metadata() -> None:
         "nullable": "Nullable",
         "type_generic": "Type Generic",
         "yeah": "sure",
+        "precision": "very precise",
+        "scale": "to the max",
+        "max_length": 9000,
     }
     result = clean_metadata(test_data)
     assert result == {


### PR DESCRIPTION
When triggering the CLI command with the `--preserve-metadata` or `--merge-metadata` flags, dataset columns are synced by sending a `GET` request to `/datasource/external_metadata/table/{{dataset-id}}`. BQ tables return extra metadata for their columns which is not compatible with the dataset update schema. 

This PR clean up the returned results.