### PR TITLE
fix(dbt): Load profiles with Jinja

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -26,7 +26,11 @@ from preset_cli.auth.token import TokenAuth
 from preset_cli.cli.superset.sync.dbt.databases import sync_database
 from preset_cli.cli.superset.sync.dbt.datasets import sync_datasets
 from preset_cli.cli.superset.sync.dbt.exposures import ModelKey, sync_exposures
-from preset_cli.cli.superset.sync.dbt.lib import apply_select, list_failed_models
+from preset_cli.cli.superset.sync.dbt.lib import (
+    apply_select,
+    list_failed_models,
+    load_profiles,
+)
 from preset_cli.cli.superset.sync.dbt.metrics import (
     get_models_from_sql,
     get_superset_metrics_per_model,
@@ -182,8 +186,7 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-branches, too-many
     with open(manifest, encoding="utf-8") as input_:
         configs = yaml.load(input_, Loader=yaml.SafeLoader)
 
-    with open(profiles, encoding="utf-8") as input_:
-        config = yaml.safe_load(input_)
+    config = load_profiles(Path(profiles), project, profile, target)
     dialect = config[project]["outputs"][target]["type"]
     mf_dialect = MFSQLEngine(dialect.upper())
 

--- a/tests/cli/superset/sync/dbt/command_test.py
+++ b/tests/cli/superset/sync/dbt/command_test.py
@@ -1905,7 +1905,7 @@ def test_dbt_core_merge_metadata(
 
 
 def test_dbt_core_load_profile_jinja_variables(
-    mocker: MockerFixture, fs: FakeFilesystem
+    mocker: MockerFixture, fs: FakeFilesystem,
 ) -> None:
     """
     Test the ``dbt-core`` command loading a profiles.yml containing Jinja
@@ -1927,7 +1927,7 @@ def test_dbt_core_load_profile_jinja_variables(
                     },
                 },
             },
-        }
+        },
     )
 
     mocker.patch.dict(

--- a/tests/cli/superset/sync/dbt/command_test.py
+++ b/tests/cli/superset/sync/dbt/command_test.py
@@ -1907,6 +1907,10 @@ def test_dbt_core_merge_metadata(
 def test_dbt_core_load_profile_jinja_variables(
     mocker: MockerFixture, fs: FakeFilesystem
 ) -> None:
+    """
+    Test the ``dbt-core`` command loading a profiles.yml containing Jinja
+    variables.
+    """
     jinja_profile_content = yaml.dump(
         {
             "default": {

--- a/tests/cli/superset/sync/dbt/command_test.py
+++ b/tests/cli/superset/sync/dbt/command_test.py
@@ -1904,6 +1904,92 @@ def test_dbt_core_merge_metadata(
     )
 
 
+def test_dbt_core_load_profile_jinja_variables(
+    mocker: MockerFixture, fs: FakeFilesystem
+) -> None:
+    jinja_profile_content = yaml.dump(
+        {
+            "default": {
+                "outputs": {
+                    "dev": {
+                        "type": "{{ env_var('DBT_TYPE') }}",
+                        "dbname": "{{ env_var('DBT_DBNAME') }}",
+                        "host": "{{ env_var('DBT_HOST') }}",
+                        "user": "{{ env_var('DBT_USER') }}",
+                        "pass": "{{ env_var('DBT_PASS') }}",
+                        "port": "{{ env_var('DBT_PORT') | as_number }}",
+                        "threads": "{{ env_var('DBT_THREADS') | as_number }}",
+                        "schema": "{{ env_var('DBT_SCHEMA') }}",
+                    },
+                },
+            },
+        }
+    )
+
+    mocker.patch.dict(
+        os.environ,
+        {
+            "DBT_DBNAME": "database",
+            "DBT_HOST": "hostname",
+            "DBT_USER": "username",
+            "DBT_PASS": "password",
+            "DBT_PORT": "5432",
+            "DBT_SCHEMA": "schema",
+            "DBT_THREADS": "1",
+            "DBT_TYPE": "postgres",
+        },
+    )
+
+    root = Path("/path/to/root")
+    fs.create_dir(root)
+    manifest = root / "default/target/manifest.json"
+    fs.create_file(manifest, contents=manifest_contents)
+    profiles = root / ".dbt/profiles.yml"
+    fs.create_file(profiles, contents=jinja_profile_content)
+    exposures = root / "models/exposures.yml"
+    fs.create_file(exposures)
+
+    SupersetClient = mocker.patch(
+        "preset_cli.cli.superset.sync.dbt.command.SupersetClient",
+    )
+    client = SupersetClient()
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+    sync_database = mocker.patch(
+        "preset_cli.cli.superset.sync.dbt.command.sync_database",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        superset_cli,
+        [
+            "https://superset.example.org/",
+            "sync",
+            "dbt-core",
+            str(manifest),
+            "--profiles",
+            str(profiles),
+            "--exposures",
+            str(exposures),
+            "--project",
+            "default",
+            "--target",
+            "dev",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    sync_database.assert_called_with(
+        client,
+        profiles,
+        "default",
+        "default",
+        "dev",
+        False,
+        False,
+        "",
+    )
+
+
 def test_dbt_core_raise_failures_flag_no_failures(
     mocker: MockerFixture,
     fs: FakeFilesystem,

--- a/tests/cli/superset/sync/dbt/command_test.py
+++ b/tests/cli/superset/sync/dbt/command_test.py
@@ -1905,7 +1905,8 @@ def test_dbt_core_merge_metadata(
 
 
 def test_dbt_core_load_profile_jinja_variables(
-    mocker: MockerFixture, fs: FakeFilesystem,
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
 ) -> None:
     """
     Test the ``dbt-core`` command loading a profiles.yml containing Jinja


### PR DESCRIPTION
fixes #279 

Uses `load_profiles` function so that it reads variables defined as JINJA on `profiles.yml`