### PR TITLE
chore: 0.2.14 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Changelog
 Next
 ====
 
+Version 0.2.14 - 2024-04-10
+===========================
+
+- Fixed an issue when syncing columns for datasets powered by BigQuery (`#278 <https://github.com/preset-io/backend-sdk/pull/278>`_).
+- Added support for syncing derived metrics that don't rely on other metrics, and also metrics including Superset-Jinja specific syntax (`#277 <https://github.com/preset-io/backend-sdk/pull/277>`_).
+
 Version 0.2.13 - 2024-03-25
 ===========================
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,4 +12,4 @@ Issue Reports
 =============
 
 If you experience bugs or general issues with ``preset-cli``, please report them in the
-[https://preset.atlassian.net/servicedesk/customer/portal/1/group/1/create/1](Preset Support Portal)
+`Preset Support Portal <https://preset.atlassian.net/servicedesk/customer/portal/1/group/1/create/1>`_.


### PR DESCRIPTION
Preparing for release `0.2.14`. Also fixed a URL syntax in the  CONTRIBUTING file.