### PR TITLE
chore(sync native): Attempt to get the DB connection UUIDs via API

### DIFF
--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -178,7 +178,16 @@ def native(  # pylint: disable=too-many-locals, too-many-arguments, too-many-bra
     base_url = URL(external_url_prefix) if external_url_prefix else None
 
     # collecting existing database UUIDs so we know if we're creating or updating
-    existing_databases = {str(uuid) for uuid in client.get_uuids("database").values()}
+    # newer versions expose the DB UUID in the API response,
+    # olders only expose it via export
+    try:
+        existing_databases = {
+            db_connection["uuid"] for db_connection in client.get_databases()
+        }
+    except KeyError:
+        existing_databases = {
+            str(uuid) for uuid in client.get_uuids("database").values()
+        }
 
     # env for Jinja2 templating
     env = dict(pair.split("=", 1) for pair in option if "=" in pair)  # type: ignore

--- a/tests/cli/superset/sync/native/command_test.py
+++ b/tests/cli/superset/sync/native/command_test.py
@@ -1,7 +1,7 @@
 """
 Tests for the native import command.
 """
-# pylint: disable=redefined-outer-name, invalid-name
+# pylint: disable=redefined-outer-name, invalid-name, too-many-lines
 
 import json
 from pathlib import Path
@@ -391,9 +391,7 @@ def test_native_password_prompt(mocker: MockerFixture, fs: FakeFilesystem) -> No
 
     prompt_for_passwords.reset_mock()
     client.get_databases.return_value = [
-        {
-            "uuid": "uuid1"
-        },
+        {"uuid": "uuid1"},
     ]
     result = runner.invoke(
         superset_cli,
@@ -554,11 +552,9 @@ def test_native_legacy_instance(mocker: MockerFixture, fs: FakeFilesystem) -> No
     client.get_databases.return_value = [
         {
             "connection_name": "Test",
-        }
+        },
     ]
-    client.get_uuids.return_value = {
-        1: "uuid1"
-    }
+    client.get_uuids.return_value = {1: "uuid1"}
     mocker.patch("preset_cli.cli.superset.sync.native.command.import_resources")
     mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
     prompt_for_passwords = mocker.patch(


### PR DESCRIPTION
During the `sync native` command, the CLI has to identify all existing DB connections in the target instance/Workspace (and their corresponding UUIDs). This is currently achieved by exporting each DB connection, and getting the `uuid` from the YAML file. 

This process was adopted because the `uuid` is not exposed in the API response for older Superset versions. However, it affects performance for two reasons:
* Each DB connection is exported (the more connections created, the longer it would take).
* There was a change in Superset that exporting a DB connection also includes all datasets, which can take time for connections with hundreds/thousands of datasets.

This PR defaults the process to get the `uuid` from the API response, and fallback in the old approach in case the API response doesn't have the `uuid` field.