### PR TITLE
fix(dbt): Avoid raising an error when syncing specific models

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -791,6 +791,7 @@ class DBTClient:  # pylint: disable=too-few-public-methods
                             name
                             description
                             type
+                            meta
                         }
                     }
                 }

--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -394,7 +394,7 @@ def get_sl_metric(
     sql = output[start:]
 
     models = get_models_from_sql(sql, dialect, model_map)
-    if len(models) > 1:
+    if not models or len(models) > 1:
         return None
     model = models[0]
 
@@ -427,7 +427,7 @@ def fetch_sl_metrics(
             continue
 
         models = get_models_from_sql(sql, dialect, model_map)
-        if len(models) > 1:
+        if not models or len(models) > 1:
             continue
         model = models[0]
 

--- a/src/preset_cli/cli/superset/sync/dbt/metrics.py
+++ b/src/preset_cli/cli/superset/sync/dbt/metrics.py
@@ -381,7 +381,7 @@ def get_models_from_sql(
     sql: str,
     dialect: MFSQLEngine,
     model_map: Dict[ModelKey, ModelSchema],
-) -> List[ModelSchema]:
+) -> Optional[List[ModelSchema]]:
     """
     Return the model associated with a SQL query.
     """
@@ -390,7 +390,7 @@ def get_models_from_sql(
 
     for table in sources:
         if ModelKey(table.db, table.name) not in model_map:
-            raise ValueError(f"Unable to find model for SQL source {table}")
+            return None
 
     return [model_map[ModelKey(table.db, table.name)] for table in sources]
 

--- a/tests/cli/superset/sync/dbt/metrics_test.py
+++ b/tests/cli/superset/sync/dbt/metrics_test.py
@@ -811,9 +811,9 @@ def test_get_models_from_sql() -> None:
         model_map,  # type: ignore
     ) == [{"name": "a"}, {"name": "b"}]
 
-    with pytest.raises(ValueError) as excinfo:
-        get_models_from_sql("SELECT 1 FROM schema.c", MFSQLEngine.BIGQUERY, {})
-    assert str(excinfo.value) == "Unable to find model for SQL source schema.c"
+    assert (
+        get_models_from_sql("SELECT 1 FROM schema.c", MFSQLEngine.BIGQUERY, {}) is None
+    )
 
 
 def test_get_superset_metrics_per_model() -> None:


### PR DESCRIPTION
The CLI allows users to sync specific models via dbt. As a consequence, when evaluating metrics it's expected that some will rely on models that aren't included in the ``model_map``. This PR changes the logic to avoid raising a  ``ValueError`` in this scenario and instead just ignore the metric.