### PR TITLE
chore(dbt): Instruct users of missing dependency when creating a Snowflake virtual dataset

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,6 +84,7 @@ exclude =
     tests
 
 [options.extras_require]
+# TODO: Implement additional optional dependencies
 snowflake = snowflake-sqlalchemy==1.4.4
 
 # Add here test requirements (semicolon/line-separated)

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,9 +84,7 @@ exclude =
     tests
 
 [options.extras_require]
-# Add here additional requirements for extra features, to install with:
-# `pip install preset-cli[PDF]` like:
-# PDF = ReportLab; RXP
+snowflake = snowflake-sqlalchemy==1.4.4
 
 # Add here test requirements (semicolon/line-separated)
 testing =

--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -8,7 +8,6 @@ import json
 import logging
 from typing import Any, Dict, List, Optional, Tuple
 
-from sqlalchemy.engine import create_engine
 from sqlalchemy.engine.url import URL as SQLAlchemyURL
 from sqlalchemy.engine.url import make_url
 from yarl import URL
@@ -16,7 +15,9 @@ from yarl import URL
 from preset_cli.api.clients.dbt import ModelSchema
 from preset_cli.api.clients.superset import SupersetClient, SupersetMetricDefinition
 from preset_cli.api.operators import OneToMany
+from preset_cli.cli.superset.sync.dbt.lib import create_sqlalchemy_engine
 from preset_cli.exceptions import CLIError, SupersetError
+from preset_cli.lib import raise_cli_errors
 
 DEFAULT_CERTIFICATION = {"details": "This table is produced by dbt"}
 
@@ -53,6 +54,7 @@ def clean_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
     return metadata
 
 
+@raise_cli_errors
 def create_dataset(
     client: SupersetClient,
     database: Dict[str, Any],
@@ -72,7 +74,7 @@ def create_dataset(
             "table_name": model.get("alias") or model["name"],
         }
     else:
-        engine = create_engine(url)
+        engine = create_sqlalchemy_engine(url)
         quote = engine.dialect.identifier_preparer.quote
         source = ".".join(quote(model[key]) for key in ("database", "schema", "name"))
         kwargs = {

--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -15,7 +15,7 @@ from yarl import URL
 from preset_cli.api.clients.dbt import ModelSchema
 from preset_cli.api.clients.superset import SupersetClient, SupersetMetricDefinition
 from preset_cli.api.operators import OneToMany
-from preset_cli.cli.superset.sync.dbt.lib import create_sqlalchemy_engine
+from preset_cli.cli.superset.sync.dbt.lib import create_engine_with_check
 from preset_cli.exceptions import CLIError, SupersetError
 from preset_cli.lib import raise_cli_errors
 
@@ -74,7 +74,7 @@ def create_dataset(
             "table_name": model.get("alias") or model["name"],
         }
     else:
-        engine = create_sqlalchemy_engine(url)
+        engine = create_engine_with_check(url)
         quote = engine.dialect.identifier_preparer.quote
         source = ".".join(quote(model[key]) for key in ("database", "schema", "name"))
         kwargs = {

--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -210,8 +210,8 @@ def create_sqlalchemy_engine(url: URL):
     except NoSuchModuleError as exc:
         string_url = str(url)
         dialect = string_url.split("://", maxsplit=1)[0]
+        # TODO: Handle more DB engines that require an additional package
         if dialect == "snowflake":
-            # TODO: Check if we can progamatically read all options listed under options.extra_require
             raise CLIError(
                 (
                     "Missing required package. "

--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union
 
 import yaml
 from jinja2 import Environment
-from sqlalchemy.engine import create_engine
+from sqlalchemy.engine import Engine, create_engine
 from sqlalchemy.engine.url import URL
 from sqlalchemy.exc import NoSuchModuleError
 
@@ -201,7 +201,7 @@ def build_snowflake_sqlalchemy_params(target: Dict[str, Any]) -> Dict[str, Any]:
     return parameters
 
 
-def create_sqlalchemy_engine(url: URL):
+def create_engine_with_check(url: URL) -> Engine:
     """
     Returns a SQLAlchemy engine or raises an error if missing required dependency.
     """

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -769,7 +769,7 @@ def test_create_dataset_virtual(mocker: MockerFixture) -> None:
     Test ``create_dataset`` for virtual datasets.
     """
     create_engine = mocker.patch(
-        "preset_cli.cli.superset.sync.dbt.lib.create_sqlalchemy_engine",
+        "preset_cli.cli.superset.sync.dbt.lib.create_engine",
     )
     create_engine().dialect.identifier_preparer.quote = lambda token: token
     client = mocker.MagicMock()

--- a/tests/cli/superset/sync/dbt/lib_test.py
+++ b/tests/cli/superset/sync/dbt/lib_test.py
@@ -18,7 +18,7 @@ from preset_cli.cli.superset.sync.dbt.lib import (
     apply_select,
     as_number,
     build_sqlalchemy_params,
-    create_sqlalchemy_engine,
+    create_engine_with_check,
     env_var,
     filter_models,
     list_failed_models,
@@ -228,32 +228,32 @@ def test_build_sqlalchemy_params_unsupported() -> None:
     )
 
 
-def test_create_sqlalchemy_engine(mocker: MockerFixture) -> None:
+def test_create_engine_with_check(mocker: MockerFixture) -> None:
     """
-    Test the ``create_sqlalchemy_engine`` method.
+    Test the ``create_engine_with_check`` method.
     """
     mock_engine = mocker.patch("preset_cli.cli.superset.sync.dbt.lib.create_engine")
-    test = create_sqlalchemy_engine(URL("blah://blah"))
+    test = create_engine_with_check(URL("blah://blah"))
     assert test == mock_engine.return_value
 
 
-def test_create_sqlalchemy_engine_missing_snowflake() -> None:
+def test_create_engine_with_check_missing_snowflake() -> None:
     """
-    Test the ``create_sqlalchemy_engine`` method when the Snowflake driver is
+    Test the ``create_engine_with_check`` method when the Snowflake driver is
     not installed.
     """
     with pytest.raises(CLIError) as excinfo:
-        create_sqlalchemy_engine(URL("snowflake://blah"))
+        create_engine_with_check(URL("snowflake://blah"))
     assert 'run ``pip install "preset-cli[snowflake]"``' in str(excinfo.value)
 
 
-def test_create_sqlalchemy_engine_missing_unknown_driver() -> None:
+def test_create_engine_with_check_missing_unknown_driver() -> None:
     """
-    Test the ``create_sqlalchemy_engine`` method when a SQLAlchemy driver is
+    Test the ``create_engine_with_check`` method when a SQLAlchemy driver is
     not installed.
     """
     with pytest.raises(NotImplementedError) as excinfo:
-        create_sqlalchemy_engine(URL("mssql+odbc://blah"))
+        create_engine_with_check(URL("mssql+odbc://blah"))
     assert "Unable to build a SQLAlchemy Engine for the mssql+odbc connection" in str(
         excinfo.value,
     )

--- a/tests/cli/superset/sync/dbt/lib_test.py
+++ b/tests/cli/superset/sync/dbt/lib_test.py
@@ -11,17 +11,20 @@ from typing import List
 import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest_mock import MockerFixture
+from sqlalchemy.engine.url import URL
 
 from preset_cli.api.clients.dbt import ModelSchema
 from preset_cli.cli.superset.sync.dbt.lib import (
     apply_select,
     as_number,
     build_sqlalchemy_params,
+    create_sqlalchemy_engine,
     env_var,
     filter_models,
     list_failed_models,
     load_profiles,
 )
+from preset_cli.exceptions import CLIError
 
 
 def test_build_sqlalchemy_params_postgres(mocker: MockerFixture) -> None:
@@ -222,6 +225,37 @@ def test_build_sqlalchemy_params_unsupported() -> None:
         "Unable to build a SQLAlchemy URI for a target of type mysql. Please file "
         "an issue at https://github.com/preset-io/backend-sdk/issues/new?"
         "labels=enhancement&title=Backend+for+mysql."
+    )
+
+
+def test_create_sqlalchemy_engine(mocker: MockerFixture) -> None:
+    """
+    Test the ``create_sqlalchemy_engine`` method.
+    """
+    mock_engine = mocker.patch("preset_cli.cli.superset.sync.dbt.lib.create_engine")
+    test = create_sqlalchemy_engine(URL("blah://blah"))
+    assert test == mock_engine.return_value
+
+
+def test_create_sqlalchemy_engine_missing_snowflake() -> None:
+    """
+    Test the ``create_sqlalchemy_engine`` method when the Snowflake driver is
+    not installed.
+    """
+    with pytest.raises(CLIError) as excinfo:
+        create_sqlalchemy_engine(URL("snowflake://blah"))
+    assert 'run ``pip install "preset-cli[snowflake]"``' in str(excinfo.value)
+
+
+def test_create_sqlalchemy_engine_missing_unknown_driver() -> None:
+    """
+    Test the ``create_sqlalchemy_engine`` method when a SQLAlchemy driver is
+    not installed.
+    """
+    with pytest.raises(NotImplementedError) as excinfo:
+        create_sqlalchemy_engine(URL("mssql+odbc://blah"))
+    assert "Unable to build a SQLAlchemy Engine for the mssql+odbc connection" in str(
+        excinfo.value,
     )
 
 


### PR DESCRIPTION
dbt is compatible with warehouses that support creating multiple DBs in the same instance (such as Snowflake). Since the `database` is specified in the DB connection string in Superset, when a model is created in a different database, the CLI creates it as a virtual dataset (using `select * from db_name.schema.table`). 

SQLAlchemy's `create_engine()` method might require the DB-specific driver to work. This PR adds proper instructions to users when facing this issue. It currently only covers `snowflake`, but covering more engines should be straightforward.