### PR TITLE
fix(dbt): Remove Redshift-specific column metadata

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -50,6 +50,7 @@ def clean_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
         "precision",
         "scale",
         "max_length",
+        "info",
     ):
         if key in metadata:
             del metadata[key]

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -1435,7 +1435,7 @@ def test_clean_metadata() -> None:
         "max_length": 9000,
         "info": {
             "custom_info": "blah",
-        }
+        },
     }
     result = clean_metadata(test_data)
     assert result == {

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -1433,6 +1433,9 @@ def test_clean_metadata() -> None:
         "precision": "very precise",
         "scale": "to the max",
         "max_length": 9000,
+        "info": {
+            "custom_info": "blah",
+        }
     }
     result = clean_metadata(test_data)
     assert result == {


### PR DESCRIPTION
Redshift reflection query returns additional metadata that isn't compatible with the Superset column schema. This PR removes the `info` key when syncing columns.

I think long-term solution is to enforce the Superset schema for columns and metrics accordingly -- I'll look into that in a future PR.