### PR TITLE
fix(import-assets): Include all dashboard depedencies when using the the --split flag

### DIFF
--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Dict, Iterator, Tuple
+from typing import Any, Dict, Iterator, Set, Tuple
 from zipfile import ZipFile
 
 import backoff
@@ -272,7 +272,7 @@ def import_resources_individually(
             ("databases", lambda config: []),
             ("datasets", lambda config: [config["database_uuid"]]),
             ("charts", lambda config: [config["dataset_uuid"]]),
-            ("dashboards", get_charts_uuids),
+            ("dashboards", get_dashboard_related_uuids),
         ]
         related_configs: Dict[str, Dict[Path, AssetConfig]] = {}
         for resource_name, get_related_uuids in imports:
@@ -297,6 +297,16 @@ def import_resources_individually(
     os.unlink(checkpoint_path)
 
 
+def get_dashboard_related_uuids(config: AssetConfig) -> Iterator[str]:
+    """
+    Extract dataset and chart UUID from a dashboard config.
+    """
+    for uuid in get_charts_uuids(config):
+        yield uuid
+    for uuid in get_dataset_filter_uuids(config):
+        yield uuid
+
+
 def get_charts_uuids(config: AssetConfig) -> Iterator[str]:
     """
     Extract chart UUID from a dashboard config.
@@ -308,6 +318,19 @@ def get_charts_uuids(config: AssetConfig) -> Iterator[str]:
             and "uuid" in child["meta"]
         ):
             yield child["meta"]["uuid"]
+
+
+def get_dataset_filter_uuids(config: AssetConfig) -> Set[str]:
+    """
+    Extract dataset UUID for datasets that are used in dashboard filters.
+    """
+    dataset_uuids = set()
+    for filter_config in config["metadata"].get("native_filter_configuration", []):
+        for target in filter_config["targets"]:
+            if uuid := target.get("datasetUuid"):
+                if uuid not in dataset_uuids:
+                    dataset_uuids.add(uuid)
+    return dataset_uuids
 
 
 def verify_db_connectivity(config: Dict[str, Any]) -> None:


### PR DESCRIPTION
The `sync native` / `import-assets` command allows users to include a `--split` flag to import resources individually. It's possible to create dashboard filters using datasets that aren't used by any chart. The logic was currently not including these datasets when importing the dashboard, resulting in an import error.