### PR TITLE
chore: avoid virtual datasets whenever possible

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -82,15 +82,10 @@ def create_dataset(
     except SupersetError as ex:
         if not no_catalog_support(ex):
             raise ex
+        del kwargs["catalog"]
 
     url = make_url(database["sqlalchemy_uri"])
-    if model_in_database(model, url):
-        kwargs = {
-            "database": database["id"],
-            "schema": model["schema"],
-            "table_name": model.get("alias") or model["name"],
-        }
-    else:
+    if not model_in_database(model, url):
         engine = create_engine_with_check(url)
         quote = engine.dialect.identifier_preparer.quote
         source = ".".join(quote(model[key]) for key in ("database", "schema", "name"))

--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -70,6 +70,19 @@ def create_dataset(
     Virtual datasets are created when the table database is different from the main
     database, for systems that support cross-database queries (Trino, BigQuery, etc.)
     """
+    kwargs = {
+        "database": database["id"],
+        "catalog": model["database"],
+        "schema": model["schema"],
+        "table_name": model.get("alias") or model["name"],
+    }
+    try:
+        # try to create dataset with catalog
+        return client.create_dataset(**kwargs)
+    except SupersetError as ex:
+        if not no_catalog_support(ex):
+            raise ex
+
     url = make_url(database["sqlalchemy_uri"])
     if model_in_database(model, url):
         kwargs = {
@@ -89,6 +102,32 @@ def create_dataset(
         }
 
     return client.create_dataset(**kwargs)
+
+
+def no_catalog_support(ex: SupersetError) -> bool:
+    """
+    Return if the error is due to a lack of catalog support.
+
+    The errors payload looks like this:
+
+        [
+            {
+                "message": json.dumps({"message": {"catalog": ["Unknown field."]}}),
+                "error_type": "UNKNOWN_ERROR",
+                "level": ErrorLevel.ERROR,
+            },
+        ]
+
+    """
+    for error in ex.errors:
+        try:
+            message = json.loads(error["message"])
+            if "Unknown field." in message["message"]["catalog"]:
+                return True
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+    return False
 
 
 def get_or_create_dataset(


### PR DESCRIPTION
With SIP-95 implemented we don't need virtual datasets anymore, yay!

Note: ideally this still requires testing with a real project, and also for the SIP-95 branch to be deployed at Preset.