### PR TITLE
fix(ModelSchema): Allow models with columns set to None

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -558,7 +558,7 @@ class ModelSchema(PostelSchema):
     name = fields.String()
     unique_id = fields.String(data_key="uniqueId")
     tags = fields.List(fields.String())
-    columns = fields.Raw()
+    columns = fields.Raw(allow_none=True)
     config = fields.Dict(fields.String(), fields.Raw(allow_none=True))
 
 


### PR DESCRIPTION
We got a report from a user that was unable to execute a dbt Cloud sync with below error:
```
marshmallow.exceptions.ValidationError: {'columns': ['Field may not be null.']}
```

This was happening because they have models returned in the API response with `columns` set to `None`. This PR changes the schema to support this scenario.