### PR TITLE
chore(dbt sync): Deprecate using the dbt_project file to trigger a dbt sync

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -5,7 +5,6 @@ A command to sync dbt models/metrics to Superset and charts/dashboards back as e
 import logging
 import os.path
 import subprocess
-import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -165,7 +164,8 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-branches, too-many
     elif file_path.name == "dbt_project.yml":
         deprecation_notice = True
         warn_message = (
-            "Passing the dbt_project.yml file is deprecated and will be removed in a future version. "
+            "Passing the dbt_project.yml file is deprecated and "
+            "will be removed in a future version. "
             "Please pass the manifest.json file instead."
         )
         _logger.warning(warn_message)

--- a/src/preset_cli/lib.py
+++ b/src/preset_cli/lib.py
@@ -127,17 +127,6 @@ def dict_merge(base: Dict[Any, Any], overrides: Dict[Any, Any]) -> None:
             base[k] = overrides[k]
 
 
-def log_warning(warn_message: str, warn_type: Type[Warning]) -> None:
-    """
-    Logs a warning message.
-    """
-    warnings.warn(
-        warn_message,
-        category=warn_type,
-        stacklevel=2,
-    )
-
-
 def raise_cli_errors(function: Callable[..., Any]) -> Callable[..., Any]:
     """
     Decorator to catch any CLIError raised and exits the execution with an error code.

--- a/src/preset_cli/lib.py
+++ b/src/preset_cli/lib.py
@@ -5,9 +5,8 @@ Basic helper functions.
 import json
 import logging
 import sys
-import warnings
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Type, cast
+from typing import Any, Callable, Dict, List, Optional, cast
 
 import click
 from requests import Response

--- a/tests/lib_test.py
+++ b/tests/lib_test.py
@@ -3,7 +3,6 @@ Tests for ``preset_cli.lib``.
 """
 
 import logging
-import warnings
 
 import pytest
 from pytest_mock import MockerFixture

--- a/tests/lib_test.py
+++ b/tests/lib_test.py
@@ -11,7 +11,6 @@ from pytest_mock import MockerFixture
 from preset_cli.exceptions import CLIError, ErrorLevel, SupersetError
 from preset_cli.lib import (
     dict_merge,
-    log_warning,
     raise_cli_errors,
     remove_root,
     setup_logging,
@@ -112,21 +111,6 @@ def test_dict_merge() -> None:
     overrides = {"a": {"c": 44}, "d": 2, "f": 3}
     dict_merge(base, overrides)
     assert base == {"a": {"b": 42, "c": 44}, "d": 2, "e": 3, "f": 3}
-
-
-def test_log_warning(mocker: MockerFixture) -> None:
-    """
-    Test ``log_warning``.
-    """
-    mock_warn = mocker.patch.object(warnings, "warn")
-    test_warning = "Test warning message"
-    test_warning_type = UserWarning
-    log_warning(test_warning, test_warning_type)
-    mock_warn.assert_called_once_with(
-        test_warning,
-        category=test_warning_type,
-        stacklevel=2,
-    )
 
 
 def test_raise_cli_errors_decorator_when_raising(


### PR DESCRIPTION
It's possible to trigger the dbt Core sync specifying the path to either the `manifest.json` file or to the `dbt_project.yml` file. The former would currently display a `DeprecationWarning`.

[dbt deprecated the `target-path` as a config in the `dbt_project.yml`](https://docs.getdbt.com/reference/global-configs/about-global-configs) (which is used when triggering the command with this file) so this PR is moving the deprecated warning to when syncing with the path to `dbt_project.yml` file specified. For simplicity, I would recommend dropping support entirely in a future release and relying solely in the `manifest.json` file.

This PR also moves away from using `warnings.warn()` as it breaks logging (not a concern when using the `preset-cli` as a standalone CLI, but could be impactful when using it as a dependency and relying on its methods).