### PR TITLE
fix(dbt Cloud): Support syncing a project without a semantic layer

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -862,7 +862,9 @@ class DBTClient:  # pylint: disable=too-few-public-methods
             variables={"environmentId": environment_id},
             headers=self.session.headers,
         )
-
+        # In case the project doesn't have a semantic layer (old versions)
+        if payload["data"] is None:
+            return []
         metric_schema = MFMetricSchema()
         metrics = [metric_schema.load(metric) for metric in payload["data"]["metrics"]]
 

--- a/tests/api/clients/dbt_test.py
+++ b/tests/api/clients/dbt_test.py
@@ -1292,6 +1292,28 @@ def test_dbt_client_get_sl_metrics(mocker: MockerFixture) -> None:
     ]
 
 
+def test_dbt_client_get_sl_metrics_no_semantic_layer(mocker: MockerFixture) -> None:
+    """
+    Test the ``get_sl_metrics`` method for old dbt projects that don't have a
+    semantic layer defined yet.
+    """
+    GraphqlClient = mocker.patch("preset_cli.api.clients.dbt.GraphqlClient")
+    GraphqlClient().execute.return_value = {
+        "data": None,
+        "errors": [
+            {
+                "message": "Empty semantic manifest was found. Ensure that you have semantic models defined.",
+                "locations": [{"line": 3, "column": 17}],
+                "path": ["metrics"],
+            },
+        ],
+    }
+    auth = Auth()
+    client = DBTClient(auth)
+
+    assert client.get_sl_metrics(108380) == []
+
+
 def test_dbt_client_get_sl_metric_sql(mocker: MockerFixture) -> None:
     """
     Test the ``get_sl_metric_sql`` method.


### PR DESCRIPTION
If the project doesn't have a semantic layer, the query to fetch semantic layer metrics return below response:
``` json
{
    "data": null,
    "errors": [
        {
            "message": "Empty semantic manifest was found. Ensure that you have semantic models defined.",
            "locations": [{"line": 3, "column": 17}],
            "path": ["metrics"],
        },
    ],
}
```

This PR adds support for this scenario.