### PR TITLE
fix(dbt Cloud): Including GraphQL path for custom endpoints

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -684,10 +684,12 @@ def get_custom_urls(access_url: Optional[str] = None) -> Dict[str, URL]:
             ),
             "discovery": parsed.with_host(
                 f"{match['code']}.metadata.{match['region']}.dbt.com",
-            ),
+            )
+            / "graphql",
             "semantic-layer": parsed.with_host(
                 f"{match['code']}.semantic-layer.{match['region']}.dbt.com",
-            ),
+            )
+            / "api/graphql",
         }
 
     raise Exception("Invalid host in custom URL")

--- a/tests/api/clients/dbt_test.py
+++ b/tests/api/clients/dbt_test.py
@@ -1377,8 +1377,8 @@ def test_get_custom_urls() -> None:
 
     assert get_custom_urls("https://ab123.us1.dbt.com") == {
         "admin": URL("https://ab123.us1.dbt.com"),
-        "discovery": URL("https://ab123.metadata.us1.dbt.com"),
-        "semantic-layer": URL("https://ab123.semantic-layer.us1.dbt.com"),
+        "discovery": URL("https://ab123.metadata.us1.dbt.com/graphql"),
+        "semantic-layer": URL("https://ab123.semantic-layer.us1.dbt.com/api/graphql"),
     }
 
     with pytest.raises(Exception) as excinfo:


### PR DESCRIPTION
In the past, dbt had a unique base domain for all API requests:
``` python
REST_ENDPOINT = URL("https://cloud.getdbt.com/")
METADATA_GRAPHQL_ENDPOINT = URL("https://metadata.cloud.getdbt.com/graphql")
SEMANTIC_LAYER_GRAPHQL_ENDPOINT = URL(
    "https://semantic-layer.cloud.getdbt.com/api/graphql",
)
```

They've changed their architecture and now customers have a dedicated URL -- this was already covered in the repo, but we were missing the paths.