### PR TITLE
chore(dbt Core): Bypass metric evaluation if final SQL is provided

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -233,7 +233,10 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-branches, too-many
                 og_metrics.append(metric)
 
             # dbt semantic layer
-            elif sl_metric := get_sl_metric(config, model_map, mf_dialect):
+            # Only validate semantic layer metrics if MF dialect is specified
+            elif mf_dialect is not None and (
+                sl_metric := get_sl_metric(config, model_map, mf_dialect)
+            ):
                 sl_metrics.append(sl_metric)
 
         superset_metrics = get_superset_metrics_per_model(og_metrics, sl_metrics)

--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -15,7 +15,6 @@ from yarl import URL
 from preset_cli.api.clients.dbt import (
     DBTClient,
     JobSchema,
-    MetricSchema,
     MFMetricWithSQLSchema,
     MFSQLEngine,
     ModelSchema,
@@ -27,6 +26,7 @@ from preset_cli.cli.superset.sync.dbt.datasets import sync_datasets
 from preset_cli.cli.superset.sync.dbt.exposures import ModelKey, sync_exposures
 from preset_cli.cli.superset.sync.dbt.lib import (
     apply_select,
+    get_og_metric_from_config,
     list_failed_models,
     load_profiles,
 )
@@ -214,18 +214,26 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-branches, too-many
     else:
         og_metrics = []
         sl_metrics = []
-        metric_schema = MetricSchema()
         for config in configs["metrics"].values():
-            if "calculation_method" in config or "sql" in config:
-                # conform to the same schema that dbt Cloud uses for metrics
-                config["dependsOn"] = config.pop("depends_on")["nodes"]
-                config["uniqueId"] = config.pop("unique_id")
-                config["dialect"] = dialect
-                og_metrics.append(metric_schema.load(config))
-            # Only validate semantic layer metrics if MF dialect is specified
-            elif mf_dialect is not None and (
-                sl_metric := get_sl_metric(config, model_map, mf_dialect)
+            # First validate if metadata is already available
+            if config.get("meta", {}).get("superset", {}).get("model") and (
+                sql := config.get("meta", {}).get("superset", {}).pop("expression")
             ):
+                metric = get_og_metric_from_config(
+                    config,
+                    dialect,
+                    depends_on=[],
+                    sql=sql,
+                )
+                og_metrics.append(metric)
+
+            # dbt legacy schema
+            elif "calculation_method" in config or "sql" in config:
+                metric = get_og_metric_from_config(config, dialect)
+                og_metrics.append(metric)
+
+            # dbt semantic layer
+            elif sl_metric := get_sl_metric(config, model_map, mf_dialect):
                 sl_metrics.append(sl_metric)
 
         superset_metrics = get_superset_metrics_per_model(og_metrics, sl_metrics)

--- a/tests/cli/superset/sync/dbt/lib_test.py
+++ b/tests/cli/superset/sync/dbt/lib_test.py
@@ -3,10 +3,11 @@ Test for ``preset_cli.cli.superset.sync.dbt.lib``.
 """
 # pylint: disable=invalid-name
 
+import copy
 import json
 import math
 from pathlib import Path
-from typing import List
+from typing import Any, Dict, List
 
 import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
@@ -21,10 +22,39 @@ from preset_cli.cli.superset.sync.dbt.lib import (
     create_engine_with_check,
     env_var,
     filter_models,
+    get_og_metric_from_config,
     list_failed_models,
     load_profiles,
 )
 from preset_cli.exceptions import CLIError
+
+base_metric_config: Dict[str, Any] = {
+    "name": "revenue_metric",
+    "expression": "price_each",
+    "description": "revenue.",
+    "calculation_method": "sum",
+    "unique_id": "metric.postgres.revenue_verbose_name_from_dbt",
+    "label": "Sales Revenue Metric and this is the dbt label",
+    "depends_on": {
+        "nodes": ["model.postgres.vehicle_sales"],
+    },
+    "metrics": [],
+    "created_at": 1701101973.269536,
+    "resource_type": "metric",
+    "fqn": ["postgres", "revenue_verbose_name_from_dbt"],
+    "model": "ref('vehicle_sales')",
+    "path": "schema.yml",
+    "package_name": "postgres",
+    "original_file_path": "models/schema.yml",
+    "refs": [{"name": "vehicle_sales", "package": None, "version": None}],
+    "time_grains": [],
+    "model_unique_id": None,
+    "meta": {
+        "superset": {
+            "d3format": ",.2f",
+        },
+    },
+}
 
 
 def test_build_sqlalchemy_params_postgres(mocker: MockerFixture) -> None:
@@ -658,7 +688,7 @@ def test_apply_select_using_path(fs: FakeFilesystem) -> None:
 
 def test_list_failed_models_single_model() -> None:
     """
-    Test ``list_failed_models()`` with a single failed model
+    Test ``list_failed_models`` with a single failed model
     """
     error_list = list_failed_models(["single_failure"])
     assert error_list == "Below model(s) failed to sync:\n - single_failure"
@@ -666,10 +696,122 @@ def test_list_failed_models_single_model() -> None:
 
 def test_list_failed_models_multiple_models() -> None:
     """
-    Test ``list_failed_models()`` with multiple failed models
+    Test ``list_failed_models`` with multiple failed models
     """
     error_list = list_failed_models(["single_failure", "another_failure"])
     assert (
         error_list
         == "Below model(s) failed to sync:\n - single_failure\n - another_failure"
     )
+
+
+def test_get_og_metric_from_config() -> None:
+    """
+    Test ``get_og_metric_from_config`` method.
+    """
+    metric_config = copy.deepcopy(base_metric_config)
+    assert get_og_metric_from_config(metric_config, "my_dialect") == {
+        "depends_on": ["model.postgres.vehicle_sales"],
+        "description": "revenue.",
+        "meta": {
+            "superset": {
+                "d3format": ",.2f",
+            },
+        },
+        "name": "revenue_metric",
+        "label": "Sales Revenue Metric and this is the dbt label",
+        "unique_id": "metric.postgres.revenue_verbose_name_from_dbt",
+        "calculation_method": "sum",
+        "expression": "price_each",
+        "dialect": "my_dialect",
+        "metrics": [],
+        "created_at": 1701101973.269536,
+        "resource_type": "metric",
+        "fqn": ["postgres", "revenue_verbose_name_from_dbt"],
+        "model": "ref('vehicle_sales')",
+        "path": "schema.yml",
+        "package_name": "postgres",
+        "original_file_path": "models/schema.yml",
+        "refs": [{"name": "vehicle_sales", "package": None, "version": None}],
+        "time_grains": [],
+        "model_unique_id": None,
+    }
+
+
+def test_get_og_metric_from_config_older_dbt_version() -> None:
+    """
+    Test ``get_og_metric_from_config`` when passing a metric built using an
+    older dbt version (< 1.3).
+    """
+    metric_config = copy.deepcopy(base_metric_config)
+    metric_config["type"] = metric_config.pop("calculation_method")
+    metric_config["sql"] = metric_config.pop("expression")
+    assert get_og_metric_from_config(metric_config, "other_dialect") == {
+        "depends_on": ["model.postgres.vehicle_sales"],
+        "description": "revenue.",
+        "meta": {
+            "superset": {
+                "d3format": ",.2f",
+            },
+        },
+        "name": "revenue_metric",
+        "label": "Sales Revenue Metric and this is the dbt label",
+        "unique_id": "metric.postgres.revenue_verbose_name_from_dbt",
+        "type": "sum",
+        "sql": "price_each",
+        "dialect": "other_dialect",
+        "metrics": [],
+        "created_at": 1701101973.269536,
+        "resource_type": "metric",
+        "fqn": ["postgres", "revenue_verbose_name_from_dbt"],
+        "model": "ref('vehicle_sales')",
+        "path": "schema.yml",
+        "package_name": "postgres",
+        "original_file_path": "models/schema.yml",
+        "refs": [{"name": "vehicle_sales", "package": None, "version": None}],
+        "time_grains": [],
+        "model_unique_id": None,
+    }
+
+
+def test_get_og_metric_from_config_ready_metric() -> None:
+    """
+    Test ``get_og_metric_from_config`` when passing a metric that already
+    contains the model's ``unique_id`` and its ``sql``.
+    """
+    metric_config = copy.deepcopy(base_metric_config)
+    metric_config["meta"]["superset"]["model"] = "model.postgres.vehicle_sales"
+
+    # Make sure that:
+    #   - depends_on is empty (so that ``skip_parsing`` gets later set to True)
+    #   - ``expression`` gets the value of ``sql``
+    #   - ``calculation_method`` is set to ``derived``
+    assert get_og_metric_from_config(
+        metric_config,
+        "preset_sql",
+        depends_on=[],
+        sql="SUM(price_each) - max(cost)",
+    ) == {
+        "depends_on": [],
+        "description": "revenue.",
+        "meta": {
+            "superset": {"d3format": ",.2f", "model": "model.postgres.vehicle_sales"},
+        },
+        "name": "revenue_metric",
+        "label": "Sales Revenue Metric and this is the dbt label",
+        "unique_id": "metric.postgres.revenue_verbose_name_from_dbt",
+        "calculation_method": "derived",
+        "expression": "SUM(price_each) - max(cost)",
+        "dialect": "preset_sql",
+        "metrics": [],
+        "created_at": 1701101973.269536,
+        "resource_type": "metric",
+        "fqn": ["postgres", "revenue_verbose_name_from_dbt"],
+        "model": "ref('vehicle_sales')",
+        "path": "schema.yml",
+        "package_name": "postgres",
+        "original_file_path": "models/schema.yml",
+        "refs": [{"name": "vehicle_sales", "package": None, "version": None}],
+        "time_grains": [],
+        "model_unique_id": None,
+    }


### PR DESCRIPTION
The CLI currently uses MetricFlow to retrieve the syntax for a metric. This current process has two issues:
* The `mf` command can take a few minutes for each metric (causing a full sync to take a long time)
* The `mf` command might return a SQL query with un-necessary `JOIN`s that is not compatible with dataset metrics in Superset.

To workaround this issue, this PR adds support for specifying the metric SQL syntax that should be used in Superset directly in `metric.meta.superset.expression`. In this case, since the metric won't be evaluated it's also required to specify the `metric.meta.superset.model` (so that the CLI knows which dataset to associate the metric):

``` yaml
metrics:
  - name: test_distinct
    description: test
    type: simple  # Will be ignored in this case
    label: Test
    type_params:
      measure: distinct_orders  # Will also be ignored
    meta:
      superset:
        expression: COUNT(DISTINCT order_id)
        model: model.vec_sales.vehicle_sales
```