### PR TITLE
fix(dbt Cloud): Update dbt metadata GraphQL query

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -817,21 +817,23 @@ class DBTClient:  # pylint: disable=too-few-public-methods
         Fetch all available metrics.
         """
         query = """
-            query GetMetrics($jobId: Int!) {
-                metrics(jobId: $jobId) {
-                    uniqueId
-                    name
-                    label
-                    type
-                    sql
-                    filters {
-                        field
-                        operator
-                        value
+            query GetMetrics($jobId: BigInt!) {
+                job(id: $jobId) {
+                    metrics {
+                        uniqueId
+                        name
+                        label
+                        type
+                        sql
+                        filters {
+                            field
+                            operator
+                            value
+                        }
+                        dependsOn
+                        description
+                        meta
                     }
-                    dependsOn
-                    description
-                    meta
                 }
             }
         """
@@ -840,9 +842,8 @@ class DBTClient:  # pylint: disable=too-few-public-methods
             variables={"jobId": job_id},
             headers=self.session.headers,
         )
-
         metric_schema = MetricSchema()
-        metrics = [metric_schema.load(metric) for metric in payload["data"]["metrics"]]
+        metrics = [metric_schema.load(metric) for metric in payload["data"]["job"]["metrics"]]
 
         return metrics
 

--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -844,7 +844,9 @@ class DBTClient:  # pylint: disable=too-few-public-methods
         )
 
         metric_schema = MetricSchema()
-        metrics = [metric_schema.load(metric) for metric in payload["data"]["job"]["metrics"]]
+        metrics = [
+            metric_schema.load(metric) for metric in payload["data"]["job"]["metrics"]
+        ]
 
         return metrics
 

--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -842,6 +842,7 @@ class DBTClient:  # pylint: disable=too-few-public-methods
             variables={"jobId": job_id},
             headers=self.session.headers,
         )
+
         metric_schema = MetricSchema()
         metrics = [metric_schema.load(metric) for metric in payload["data"]["job"]["metrics"]]
 

--- a/tests/api/clients/dbt_test.py
+++ b/tests/api/clients/dbt_test.py
@@ -1135,21 +1135,23 @@ def test_dbt_client_get_og_metrics(mocker: MockerFixture) -> None:
     GraphqlClient = mocker.patch("preset_cli.api.clients.dbt.GraphqlClient")
     GraphqlClient().execute.return_value = {
         "data": {
-            "metrics": [
-                {
-                    "uniqueId": "metric.jaffle_shop.new_customers",
-                    "name": "new_customers",
-                    "label": "New Customers",
-                    "type": "count",
-                    "sql": "customer_id",
-                    "filters": [
-                        {"field": "number_of_orders", "operator": ">", "value": "0"},
-                    ],
-                    "dependsOn": ["model.jaffle_shop.customers"],
-                    "description": "The number of paid customers using the product",
-                    "meta": {},
-                },
-            ],
+            "job": {
+                "metrics": [
+                    {
+                        "uniqueId": "metric.jaffle_shop.new_customers",
+                        "name": "new_customers",
+                        "label": "New Customers",
+                        "type": "count",
+                        "sql": "customer_id",
+                        "filters": [
+                            {"field": "number_of_orders", "operator": ">", "value": "0"},
+                        ],
+                        "dependsOn": ["model.jaffle_shop.customers"],
+                        "description": "The number of paid customers using the product",
+                        "meta": {},
+                    },
+                ],
+            },
         },
     }
     auth = Auth()

--- a/tests/api/clients/dbt_test.py
+++ b/tests/api/clients/dbt_test.py
@@ -1144,7 +1144,11 @@ def test_dbt_client_get_og_metrics(mocker: MockerFixture) -> None:
                         "type": "count",
                         "sql": "customer_id",
                         "filters": [
-                            {"field": "number_of_orders", "operator": ">", "value": "0"},
+                            {
+                                "field": "number_of_orders",
+                                "operator": ">",
+                                "value": "0",
+                            },
                         ],
                         "dependsOn": ["model.jaffle_shop.customers"],
                         "description": "The number of paid customers using the product",


### PR DESCRIPTION
We were previously fetching legacy metrics with the `metrics(jobId: $jobId)` query, which was not working properly with new jobs as the `jobId` is an `Int!` for this query (and job IDs are exceeding the 32-bit limit).

This PR uses the `job(id: $jobId)` query which accepts/support a `BigInt!`.