### PR TITLE
feat(dbt sync): Support metric key remapping

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -612,6 +612,8 @@ class MFMetricSchema(PostelSchema):
     name = fields.String()
     description = fields.String()
     type = PostelEnumField(MFMetricType)
+    meta = fields.Raw()
+    label = fields.String()
 
 
 class MFSQLEngine(str, Enum):
@@ -860,6 +862,7 @@ class DBTClient:  # pylint: disable=too-few-public-methods
                     name
                     description
                     type
+                    label
                 }
             }
         """

--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -574,15 +574,22 @@ class FilterSchema(PostelSchema):
 
 class MetricSchema(PostelSchema):
     """
-    Schema for a metric.
+    Base schema for a dbt metric.
+    """
+
+    name = fields.String()
+    label = fields.String()
+    description = fields.String()
+    meta = fields.Raw()
+
+
+class OGMetricSchema(MetricSchema):
+    """
+    Schema for an OG metric.
     """
 
     depends_on = fields.List(fields.String(), data_key="dependsOn")
-    description = fields.String()
     filters = fields.List(fields.Nested(FilterSchema))
-    meta = fields.Raw()
-    name = fields.String()
-    label = fields.String()
     sql = fields.String()
     type = fields.String()
     unique_id = fields.String(data_key="uniqueId")
@@ -604,16 +611,12 @@ class MFMetricType(str, Enum):
     DERIVED = "DERIVED"
 
 
-class MFMetricSchema(PostelSchema):
+class MFMetricSchema(MetricSchema):
     """
     Schema for a MetricFlow metric.
     """
 
-    name = fields.String()
-    description = fields.String()
     type = PostelEnumField(MFMetricType)
-    meta = fields.Raw()
-    label = fields.String()
 
 
 class MFSQLEngine(str, Enum):
@@ -814,7 +817,7 @@ class DBTClient:  # pylint: disable=too-few-public-methods
 
         return models
 
-    def get_og_metrics(self, job_id: int) -> List[MetricSchema]:
+    def get_og_metrics(self, job_id: int) -> List[OGMetricSchema]:
         """
         Fetch all available metrics.
         """
@@ -845,7 +848,7 @@ class DBTClient:  # pylint: disable=too-few-public-methods
             headers=self.session.headers,
         )
 
-        metric_schema = MetricSchema()
+        metric_schema = OGMetricSchema()
         metrics = [
             metric_schema.load(metric) for metric in payload["data"]["job"]["metrics"]
         ]

--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -416,11 +416,13 @@ def get_sl_metric(
     return mf_metric_schema.load(
         {
             "name": metric["name"],
+            "label": metric["label"],
             "type": metric["type"],
             "description": metric["description"],
             "sql": sql,
             "dialect": dialect.value,
             "model": model["unique_id"],
+            "meta": metric.get("meta", metric.get("config", {}).get("meta", {})),
         },
     )
 
@@ -452,9 +454,11 @@ def fetch_sl_metrics(
                     "name": metric["name"],
                     "type": metric["type"],
                     "description": metric["description"],
+                    "label": metric["label"],
                     "sql": sql,
                     "dialect": dialect.value,
                     "model": model["unique_id"],
+                    # TODO (Vitor-Avila): Pull meta from ``config.meta`` (supported in versionless)
                 },
             ),
         )

--- a/src/preset_cli/cli/superset/sync/dbt/command.py
+++ b/src/preset_cli/cli/superset/sync/dbt/command.py
@@ -215,9 +215,14 @@ def dbt_core(  # pylint: disable=too-many-arguments, too-many-branches, too-many
         og_metrics = []
         sl_metrics = []
         for config in configs["metrics"].values():
+            # dbt is shifting from `metric.meta` to `metric.config.meta`
+            config["meta"] = config.get("meta") or config.get("config", {}).get(
+                "meta",
+                {},
+            )
             # First validate if metadata is already available
-            if config.get("meta", {}).get("superset", {}).get("model") and (
-                sql := config.get("meta", {}).get("superset", {}).pop("expression")
+            if config["meta"].get("superset", {}).get("model") and (
+                sql := config["meta"].get("superset", {}).pop("expression")
             ):
                 metric = get_og_metric_from_config(
                     config,
@@ -422,7 +427,7 @@ def get_sl_metric(
             "sql": sql,
             "dialect": dialect.value,
             "model": model["unique_id"],
-            "meta": metric.get("meta", metric.get("config", {}).get("meta", {})),
+            "meta": metric["meta"],
         },
     )
 

--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -16,7 +16,7 @@ from sqlalchemy.engine import Engine, create_engine
 from sqlalchemy.engine.url import URL
 from sqlalchemy.exc import NoSuchModuleError
 
-from preset_cli.api.clients.dbt import MetricSchema, ModelSchema
+from preset_cli.api.clients.dbt import MetricSchema, ModelSchema, OGMetricSchema
 from preset_cli.exceptions import CLIError
 
 _logger = logging.getLogger(__name__)
@@ -505,11 +505,11 @@ def get_og_metric_from_config(
     dialect: str,
     depends_on: Optional[List[str]] = None,
     sql: Optional[str] = None,
-) -> MetricSchema:
+) -> OGMetricSchema:
     """
     Return an og metric from the config, adhering to the dbt Cloud schema.
     """
-    metric_schema = MetricSchema()
+    metric_schema = OGMetricSchema()
     if depends_on is not None:
         metric_config["dependsOn"] = depends_on
         metric_config.pop("depends_on", None)
@@ -528,10 +528,11 @@ def get_og_metric_from_config(
     return metric_schema.load(metric_config)
 
 
-def parse_metric_meta(metric_meta: Dict[str, Any]) -> Dict[str, Any]:
+def parse_metric_meta(metric: MetricSchema) -> Dict[str, Any]:
     """
     Parses the metric's meta information.
     """
+    metric_meta = metric.get("meta", metric.get("config", {}).get("meta", {}))
     kwargs = metric_meta.pop("superset", {})
     metric_name_override = kwargs.pop("metric_name", None)
     return {

--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -532,11 +532,10 @@ def parse_metric_meta(metric: MetricSchema) -> Dict[str, Any]:
     """
     Parses the metric's meta information.
     """
-    metric_meta = metric.get("meta", metric.get("config", {}).get("meta", {}))
-    kwargs = metric_meta.pop("superset", {})
+    kwargs = metric.get("meta", {}).pop("superset", {})
     metric_name_override = kwargs.pop("metric_name", None)
     return {
-        "meta": metric_meta,
+        "meta": metric.get("meta", {}),
         "kwargs": kwargs,
         "metric_name_override": metric_name_override,
     }

--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -526,3 +526,16 @@ def get_og_metric_from_config(
     metric_config["dialect"] = dialect
 
     return metric_schema.load(metric_config)
+
+
+def parse_metric_meta(metric_meta: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Parses the metric's meta information.
+    """
+    kwargs = metric_meta.pop("superset", {})
+    metric_name_override = kwargs.pop("metric_name", None)
+    return {
+        "meta": metric_meta,
+        "kwargs": kwargs,
+        "metric_name_override": metric_name_override,
+    }

--- a/tests/cli/superset/sync/dbt/command_test.py
+++ b/tests/cli/superset/sync/dbt/command_test.py
@@ -190,9 +190,14 @@ dbt_cloud_metrics = [
 ]
 
 dbt_metricflow_metrics = [
-    {"name": "a", "type": "Simple", "description": "The simplest metric"},
-    {"name": "b", "type": "derived", "description": "Too complex for Superset"},
-    {"name": "c", "type": "derived", "description": "Multiple models"},
+    {"name": "a", "type": "Simple", "description": "The simplest metric", "label": "A"},
+    {
+        "name": "b",
+        "type": "derived",
+        "description": "Too complex for Superset",
+        "label": "B",
+    },
+    {"name": "c", "type": "derived", "description": "Multiple models", "label": "C"},
 ]
 
 
@@ -3065,7 +3070,8 @@ def test_dbt_cloud(mocker: MockerFixture) -> None:
                     "expression": "COUNT(*)",
                     "metric_name": "a",
                     "metric_type": "Simple",
-                    "verbose_name": "a",
+                    "verbose_name": "A",
+                    "extra": "{}",
                 },
             ],
         },

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -12,7 +12,7 @@ from pytest_mock import MockerFixture
 from sqlalchemy.engine.url import make_url
 from yarl import URL
 
-from preset_cli.api.clients.dbt import MetricSchema, ModelSchema
+from preset_cli.api.clients.dbt import ModelSchema, OGMetricSchema
 from preset_cli.api.clients.superset import SupersetMetricDefinition
 from preset_cli.cli.superset.sync.dbt.datasets import (
     DEFAULT_CERTIFICATION,
@@ -36,7 +36,7 @@ from preset_cli.exceptions import (
     SupersetError,
 )
 
-metric_schema = MetricSchema()
+metric_schema = OGMetricSchema()
 
 metrics: Dict[str, List[SupersetMetricDefinition]] = {
     "model.superset_examples.messages_channels": [

--- a/tests/cli/superset/sync/dbt/lib_test.py
+++ b/tests/cli/superset/sync/dbt/lib_test.py
@@ -25,6 +25,7 @@ from preset_cli.cli.superset.sync.dbt.lib import (
     get_og_metric_from_config,
     list_failed_models,
     load_profiles,
+    parse_metric_meta,
 )
 from preset_cli.exceptions import CLIError
 
@@ -814,4 +815,33 @@ def test_get_og_metric_from_config_ready_metric() -> None:
         "refs": [{"name": "vehicle_sales", "package": None, "version": None}],
         "time_grains": [],
         "model_unique_id": None,
+    }
+
+
+def test_parse_metric_meta() -> None:
+    """
+    Test the ``parse_metric_meta`` helper.
+    """
+    assert parse_metric_meta(
+        {
+            "superset": {
+                "d3format": ",.2f",
+                "metric_name": "revenue_metric",
+            },
+            "airflow": "other_id",
+        },
+    ) == {
+        "meta": {
+            "airflow": "other_id",
+        },
+        "kwargs": {
+            "d3format": ",.2f",
+        },
+        "metric_name_override": "revenue_metric",
+    }
+
+    assert parse_metric_meta({}) == {
+        "meta": {},
+        "kwargs": {},
+        "metric_name_override": None,
     }

--- a/tests/cli/superset/sync/dbt/lib_test.py
+++ b/tests/cli/superset/sync/dbt/lib_test.py
@@ -854,14 +854,12 @@ def test_parse_metric_meta() -> None:
                 "name": "Sabe but using config",
                 "label": "Meta inside config",
                 "description": "",
-                "config": {
-                    "meta": {
-                        "superset": {
-                            "d3format": ",.2f",
-                            "metric_name": "revenue_metric",
-                        },
-                        "airflow": "other_id",
+                "meta": {
+                    "superset": {
+                        "d3format": ",.2f",
+                        "metric_name": "revenue_metric",
                     },
+                    "airflow": "other_id",
                 },
             },
         ),

--- a/tests/cli/superset/sync/dbt/metrics_test.py
+++ b/tests/cli/superset/sync/dbt/metrics_test.py
@@ -875,12 +875,14 @@ def test_get_superset_metrics_per_model() -> None:
                 "calculation_method": "sum",
                 "expression": "1",
                 "label": "Sales",
+                "meta": {},
             },
             {
                 "name": "multi-model",
                 "unique_id": "multi-model",
                 "depends_on": ["a", "b"],
                 "calculation_method": "derived",
+                "meta": {},
             },
             {
                 "name": "a",
@@ -900,11 +902,9 @@ def test_get_superset_metrics_per_model() -> None:
                 "depends_on": ["customers"],
                 "calculation_method": "sum",
                 "expression": "1",
-                "config": {
-                    "meta": {
-                        "superset": {
-                            "warning_text": "meta under config",
-                        },
+                "meta": {
+                    "superset": {
+                        "warning_text": "meta under config",
                     },
                 },
             },
@@ -915,11 +915,9 @@ def test_get_superset_metrics_per_model() -> None:
                 "depends_on": ["customers"],
                 "calculation_method": "max",
                 "expression": "1",
-                "config": {
-                    "meta": {
-                        "superset": {
-                            "metric_name": "new_key",
-                        },
+                "meta": {
+                    "superset": {
+                        "metric_name": "new_key",
                     },
                 },
             },
@@ -937,6 +935,7 @@ def test_get_superset_metrics_per_model() -> None:
                 "sql": "SELECT COUNT(1) FROM a.b.c",
                 "dialect": MFSQLEngine.BIGQUERY,
                 "model": "new-model",
+                "meta": {},
             },
             {
                 "name": "other_new",
@@ -1032,6 +1031,7 @@ def test_get_superset_metrics_per_model_og_derived(
                 "depends_on": ["orders"],
                 "calculation_method": "sum",
                 "expression": "1",
+                "meta": {},
             },
         ),
         og_metric_schema.load(
@@ -1041,6 +1041,7 @@ def test_get_superset_metrics_per_model_og_derived(
                 "depends_on": ["orders"],
                 "calculation_method": "sum",
                 "expression": "price_each",
+                "meta": {},
             },
         ),
         og_metric_schema.load(
@@ -1050,6 +1051,7 @@ def test_get_superset_metrics_per_model_og_derived(
                 "depends_on": [],
                 "calculation_method": "derived",
                 "expression": "price_each * 1.2",
+                "meta": {},
             },
         ),
         og_metric_schema.load(
@@ -1092,6 +1094,7 @@ SUM(
     {% endfor %}
 )
 """,
+                "meta": {},
             },
         ),
         og_metric_schema.load(
@@ -1102,6 +1105,7 @@ SUM(
                 "dialect": "postgres",
                 "calculation_method": "derived",
                 "expression": "derived_metric_with_jinja_and_other_metric / revenue",
+                "meta": {},
             },
         ),
         og_metric_schema.load(

--- a/tests/cli/superset/sync/dbt/metrics_test.py
+++ b/tests/cli/superset/sync/dbt/metrics_test.py
@@ -9,7 +9,11 @@ from typing import Dict
 import pytest
 from pytest_mock import MockerFixture
 
-from preset_cli.api.clients.dbt import MetricSchema, MFMetricWithSQLSchema, MFSQLEngine
+from preset_cli.api.clients.dbt import (
+    MFMetricWithSQLSchema,
+    MFSQLEngine,
+    OGMetricSchema,
+)
 from preset_cli.cli.superset.sync.dbt.exposures import ModelKey
 from preset_cli.cli.superset.sync.dbt.metrics import (
     convert_metric_flow_to_superset,
@@ -27,8 +31,8 @@ def test_get_metric_expression() -> None:
     """
     Tests for ``get_metric_expression``.
     """
-    metric_schema = MetricSchema()
-    metrics: Dict[str, MetricSchema] = {
+    metric_schema = OGMetricSchema()
+    metrics: Dict[str, OGMetricSchema] = {
         "one": metric_schema.load(
             {
                 "type": "count",
@@ -121,8 +125,8 @@ def test_get_metric_expression_new_schema() -> None:
 
     See https://docs.getdbt.com/guides/migration/versions/upgrading-to-v1.3#for-users-of-dbt-metrics
     """
-    metric_schema = MetricSchema()
-    metrics: Dict[str, MetricSchema] = {
+    metric_schema = OGMetricSchema()
+    metrics: Dict[str, OGMetricSchema] = {
         "one": metric_schema.load(
             {
                 "calculation_method": "count",
@@ -146,8 +150,8 @@ def test_get_metric_expression_derived_legacy() -> None:
     """
     Test ``get_metric_expression`` with derived metrics created using a legacy dbt version.
     """
-    metric_schema = MetricSchema()
-    metrics: Dict[str, MetricSchema] = {
+    metric_schema = OGMetricSchema()
+    metrics: Dict[str, OGMetricSchema] = {
         "revenue_verbose_name_from_dbt": metric_schema.load(
             {
                 "name": "revenue_verbose_name_from_dbt",
@@ -476,7 +480,7 @@ def test_get_metric_models() -> None:
     """
     Tests for ``get_metric_models``.
     """
-    metric_schema = MetricSchema()
+    metric_schema = OGMetricSchema()
     metrics = [
         metric_schema.load(
             {
@@ -859,7 +863,7 @@ def test_get_superset_metrics_per_model() -> None:
     Tests for the ``get_superset_metrics_per_model`` function.
     """
     mf_metric_schema = MFMetricWithSQLSchema()
-    og_metric_schema = MetricSchema()
+    og_metric_schema = OGMetricSchema()
 
     og_metrics = [
         og_metric_schema.load(obj)
@@ -1018,7 +1022,7 @@ def test_get_superset_metrics_per_model_og_derived(
     Tests for the ``get_superset_metrics_per_model`` function
     with derived OG metrics.
     """
-    og_metric_schema = MetricSchema()
+    og_metric_schema = OGMetricSchema()
 
     og_metrics = [
         og_metric_schema.load(
@@ -1219,7 +1223,7 @@ def test_replace_metric_syntax() -> None:
     """
     Test the ``replace_metric_syntax`` method.
     """
-    og_metric_schema = MetricSchema()
+    og_metric_schema = OGMetricSchema()
     sql = "revenue - cost"
     metrics = {
         "revenue": og_metric_schema.load(


### PR DESCRIPTION
dbt introduced new restrictions to metric names with MetricFlow (for example, it's no longer possible to have `__` in metric names). As a consequence, in order to upgrade to a supported version customers have to update all their metric names according to new rules. The metric mapping with Preset happens based on the metric name, so a re-name in dbt would result in new metrics in Preset, leaving old metrics out of sync. 

This PR introduces a way to map a dbt metric with a Preset metric with diverging names, to minimize the impact of this change. 

This PR also improves the `meta` handling in general for metrics (so that Preset-specific fields can be controlled through dbt) and also improves the handling for the metric `label` (it wasn't being pulled from MetricFlow metrics).