### PR TITLE
fix(pre-commit): Updating mirrors-mypy dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
     - types-requests
     - types-freezegun
     - types-python-dateutil
-    - types-pkg_resources
+    - types-setuptools
     - types-PyYAML
     - types-tabulate
 - repo: https://github.com/asottile/add-trailing-comma


### PR DESCRIPTION
[types-pkg-resources](https://pypi.org/project/types-pkg-resources) have been yanked -- they recommend using `types-setuptools` instead.