### PR TITLE
fix(dbt): Keep syncing datasets if one failed to sync columns

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -349,11 +349,17 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-arguments
         # compute columns
         final_dataset_columns = []
         if not reload_columns:
-            refreshed_columns_list = client.get_refreshed_dataset_columns(dataset["id"])
-            final_dataset_columns = compute_columns(
-                dataset["columns"],
-                refreshed_columns_list,
-            )
+            try:
+                refreshed_columns_list = client.get_refreshed_dataset_columns(
+                    dataset["id"],
+                )
+                final_dataset_columns = compute_columns(
+                    dataset["columns"],
+                    refreshed_columns_list,
+                )
+            except SupersetError:
+                failed_datasets.append(model["unique_id"])
+                continue
 
         # compute update payload
         update = compute_dataset_metadata(

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -261,6 +261,34 @@ def test_sync_datasets_second_update_fails(mocker: MockerFixture) -> None:
     assert failed == [models[0]["unique_id"]]
 
 
+def test_sync_datasets_sync_columns_fails(mocker: MockerFixture) -> None:
+    """
+    Test ``sync_datasets`` when the request to sync columns fails.
+    """
+    client = mocker.MagicMock()
+    client.get_refreshed_dataset_columns.side_effect = [SupersetError([error])]
+    mocker.patch(
+        "preset_cli.cli.superset.sync.dbt.datasets.get_or_create_dataset",
+        return_value={"id": 1, "metrics": [], "columns": []},
+    )
+    mocker.patch(
+        "preset_cli.cli.superset.sync.dbt.datasets.compute_metrics",
+    )
+    working, failed = sync_datasets(
+        client=client,
+        models=models,
+        metrics=metrics,
+        database={"id": 1},
+        disallow_edits=False,
+        external_url_prefix="",
+        reload_columns=False,
+    )
+
+    client.update_dataset.assert_not_called()
+    assert working == []
+    assert failed == [models[0]["unique_id"]]
+
+
 def test_sync_datasets_with_alias(mocker: MockerFixture) -> None:
     """
     Test ``sync_datasets`` when the model has an alias.


### PR DESCRIPTION
When syncing datasets with the `--preserve-metadata` or `--merge-metadata` flags, a request to sync the dataset columns is triggered. Currently, in case this request fails the command execution is aborted. 

This PR gracefully handles failures, adding the failed dataset to the list of `failed_datasets` (which can be listed at the end in case `--raise-failures` is used).