### PR TITLE
chore(dbt Cloud): Support versionless jobs

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -850,7 +850,9 @@ class DBTClient:  # pylint: disable=too-few-public-methods
 
         metric_schema = OGMetricSchema()
         metrics = [
-            metric_schema.load(metric) for metric in payload["data"]["job"]["metrics"]
+            metric_schema.load(metric)
+            for metric in payload["data"]["job"]["metrics"]
+            if metric.get("sql")
         ]
 
         return metrics


### PR DESCRIPTION
We support both legacy/OG metrics and also semantic layer metrics. To handle both cases, the dbt Cloud integration triggers two GraphQL calls:
* one to fetch OG metrics (via `get_og_metrics`).
* one to fetch SL metrics (via `get_sl_metrics`).

dbt recently released [versionless](https://docs.getdbt.com/docs/dbt-versions/versionless-cloud), so that you don't have to manage/upgrade environment versions. With `versionless` jobs, both OG and SL metrics are returned by the GraphQL call used in `get_og_metrics`.

This PR skips SL metrics in this first request, as they'll be properly handled in the second one.