### PR TITLE
Add option to force Unix EOL on YAML export via the CLI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,6 @@ repos:
   hooks:
   - id: pylint
     name: pylint
-    entry: pylint --disable=use-implicit-booleaness-not-comparison,fixme,duplicate-code
+    entry: pylint --disable=use-implicit-booleaness-not-comparison,fixme,duplicate-code,broad-exception-raised,R
     language: system
     types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,6 @@ repos:
   hooks:
   - id: pylint
     name: pylint
-    entry: pylint --disable=use-implicit-booleaness-not-comparison,fixme,duplicate-code,broad-exception-raised,R
+    entry: pylint --disable=use-implicit-booleaness-not-comparison,fixme,duplicate-code
     language: system
     types: [python]

--- a/src/preset_cli/cli/superset/export.py
+++ b/src/preset_cli/cli/superset/export.py
@@ -21,6 +21,11 @@ JINJA2_CLOSE_MARKER = "__JINJA2_CLOSE__"
 assert JINJA2_OPEN_MARKER != JINJA2_CLOSE_MARKER
 
 
+def get_newline_char(force_unix_eol: bool = False) -> str | None:
+    """Returns the newline character used by the open function"""
+    return "\n" if force_unix_eol else None
+
+
 @click.command()
 @click.argument("directory", type=click.Path(exists=True, resolve_path=True))
 @click.option(
@@ -158,10 +163,7 @@ def export_resource(  # pylint: disable=too-many-arguments, too-many-locals
 
             file_contents = yaml.dump(asset_content, sort_keys=False)
 
-        if force_unix_eol:
-            newline = "\n"
-        else:
-            newline = None
+        newline = get_newline_char(force_unix_eol)
         with open(target, "w", encoding="utf-8", newline=newline) as output:
             output.write(file_contents)
 
@@ -257,10 +259,7 @@ def export_users(
         {k: v for k, v in user.items() if k != "id"} for user in client.export_users()
     ]
 
-    if force_unix_eol:
-        newline = "\n"
-    else:
-        newline = None
+    newline = get_newline_char(force_unix_eol)
     with open(path, "w", encoding="utf-8", newline=newline) as output:
         yaml.dump(users, output)
 
@@ -290,10 +289,7 @@ def export_roles(
     url = URL(ctx.obj["INSTANCE"])
     client = SupersetClient(url, auth)
 
-    if force_unix_eol:
-        newline = "\n"
-    else:
-        newline = None
+    newline = get_newline_char(force_unix_eol)
     with open(path, "w", encoding="utf-8", newline=newline) as output:
         yaml.dump(list(client.export_roles()), output)
 
@@ -323,10 +319,7 @@ def export_rls(
     url = URL(ctx.obj["INSTANCE"])
     client = SupersetClient(url, auth)
 
-    if force_unix_eol:
-        newline = "\n"
-    else:
-        newline = None
+    newline = get_newline_char(force_unix_eol)
     with open(path, "w", encoding="utf-8", newline=newline) as output:
         yaml.dump(list(client.export_rls()), output, sort_keys=False)
 
@@ -367,9 +360,6 @@ def export_ownership(
                 },
             )
 
-    if force_unix_eol:
-        newline = "\n"
-    else:
-        newline = None
+    newline = get_newline_char(force_unix_eol)
     with open(path, "w", encoding="utf-8", newline=newline) as output:
         yaml.dump(dict(ownership), output)

--- a/src/preset_cli/cli/superset/export.py
+++ b/src/preset_cli/cli/superset/export.py
@@ -6,7 +6,7 @@ import json
 import re
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Callable, List, Set, Tuple
+from typing import Any, Callable, List, Set, Tuple, Union
 from zipfile import ZipFile
 
 import click
@@ -21,7 +21,7 @@ JINJA2_CLOSE_MARKER = "__JINJA2_CLOSE__"
 assert JINJA2_OPEN_MARKER != JINJA2_CLOSE_MARKER
 
 
-def get_newline_char(force_unix_eol: bool = False) -> str | None:
+def get_newline_char(force_unix_eol: bool = False) -> Union[str, None]:
     """Returns the newline character used by the open function"""
     return "\n" if force_unix_eol else None
 

--- a/src/preset_cli/cli/superset/export.py
+++ b/src/preset_cli/cli/superset/export.py
@@ -39,7 +39,7 @@ assert JINJA2_OPEN_MARKER != JINJA2_CLOSE_MARKER
     "--force-unix-eol",
     is_flag=True,
     default=False,
-    help="Force Unix end-of-line characters, otherwise use system default"
+    help="Force Unix end-of-line characters, otherwise use system default",
 )
 @click.option(
     "--asset-type",
@@ -77,7 +77,7 @@ def export_assets(  # pylint: disable=too-many-locals, too-many-arguments
     dashboard_ids: List[str],
     overwrite: bool = False,
     disable_jinja_escaping: bool = False,
-    force_unix_eol: bool = False
+    force_unix_eol: bool = False,
 ) -> None:
     """
     Export DBs/datasets/charts/dashboards to a directory.
@@ -107,7 +107,7 @@ def export_assets(  # pylint: disable=too-many-locals, too-many-arguments
                 overwrite,
                 disable_jinja_escaping,
                 skip_related=not ids_requested,
-                force_unix_eol=force_unix_eol
+                force_unix_eol=force_unix_eol,
             )
 
 
@@ -119,7 +119,7 @@ def export_resource(  # pylint: disable=too-many-arguments, too-many-locals
     overwrite: bool,
     disable_jinja_escaping: bool,
     skip_related: bool = True,
-    force_unix_eol: bool = False
+    force_unix_eol: bool = False,
 ) -> None:
     """
     Export a given resource and unzip it in a directory.
@@ -238,10 +238,14 @@ def jinja_escaper(value: str) -> str:
     "--force-unix-eol",
     is_flag=True,
     default=False,
-    help="Force Unix end-of-line characters, otherwise use system default"
+    help="Force Unix end-of-line characters, otherwise use system default",
 )
 @click.pass_context
-def export_users(ctx: click.core.Context, path: str, force_unix_eol: bool=False) -> None:
+def export_users(
+    ctx: click.core.Context,
+    path: str,
+    force_unix_eol: bool = False,
+) -> None:
     """
     Export users and their roles to a YAML file.
     """
@@ -271,10 +275,14 @@ def export_users(ctx: click.core.Context, path: str, force_unix_eol: bool=False)
     "--force-unix-eol",
     is_flag=True,
     default=False,
-    help="Force Unix end-of-line characters, otherwise use system default"
+    help="Force Unix end-of-line characters, otherwise use system default",
 )
 @click.pass_context
-def export_roles(ctx: click.core.Context, path: str, force_unix_eol: bool=False) -> None:
+def export_roles(
+    ctx: click.core.Context,
+    path: str,
+    force_unix_eol: bool = False,
+) -> None:
     """
     Export roles to a YAML file.
     """
@@ -300,10 +308,14 @@ def export_roles(ctx: click.core.Context, path: str, force_unix_eol: bool=False)
     "--force-unix-eol",
     is_flag=True,
     default=False,
-    help="Force Unix end-of-line characters, otherwise use system default"
+    help="Force Unix end-of-line characters, otherwise use system default",
 )
 @click.pass_context
-def export_rls(ctx: click.core.Context, path: str, force_unix_eol: bool=False) -> None:
+def export_rls(
+    ctx: click.core.Context,
+    path: str,
+    force_unix_eol: bool = False,
+) -> None:
     """
     Export RLS rules to a YAML file.
     """
@@ -329,10 +341,14 @@ def export_rls(ctx: click.core.Context, path: str, force_unix_eol: bool=False) -
     "--force-unix-eol",
     is_flag=True,
     default=False,
-    help="Force Unix end-of-line characters, otherwise use system default"
+    help="Force Unix end-of-line characters, otherwise use system default",
 )
 @click.pass_context
-def export_ownership(ctx: click.core.Context, path: str, force_unix_eol: bool=False) -> None:
+def export_ownership(
+    ctx: click.core.Context,
+    path: str,
+    force_unix_eol: bool = False,
+) -> None:
     """
     Export DBs/datasets/charts/dashboards ownership to a YAML file.
     """

--- a/src/preset_cli/cli/superset/export.py
+++ b/src/preset_cli/cli/superset/export.py
@@ -36,6 +36,12 @@ assert JINJA2_OPEN_MARKER != JINJA2_CLOSE_MARKER
     help="Disable Jinja template escaping",
 )
 @click.option(
+    "--force-unix-eol",
+    is_flag=True,
+    default=False,
+    help="Force Unix end-of-line characters, otherwise use system default"
+)
+@click.option(
     "--asset-type",
     help="Asset type",
     multiple=True,
@@ -71,6 +77,7 @@ def export_assets(  # pylint: disable=too-many-locals, too-many-arguments
     dashboard_ids: List[str],
     overwrite: bool = False,
     disable_jinja_escaping: bool = False,
+    force_unix_eol: bool = False
 ) -> None:
     """
     Export DBs/datasets/charts/dashboards to a directory.
@@ -100,6 +107,7 @@ def export_assets(  # pylint: disable=too-many-locals, too-many-arguments
                 overwrite,
                 disable_jinja_escaping,
                 skip_related=not ids_requested,
+                force_unix_eol=force_unix_eol
             )
 
 
@@ -111,6 +119,7 @@ def export_resource(  # pylint: disable=too-many-arguments, too-many-locals
     overwrite: bool,
     disable_jinja_escaping: bool,
     skip_related: bool = True,
+    force_unix_eol: bool = False
 ) -> None:
     """
     Export a given resource and unzip it in a directory.
@@ -149,7 +158,11 @@ def export_resource(  # pylint: disable=too-many-arguments, too-many-locals
 
             file_contents = yaml.dump(asset_content, sort_keys=False)
 
-        with open(target, "w", encoding="utf-8") as output:
+        if force_unix_eol:
+            newline = "\n"
+        else:
+            newline = None
+        with open(target, "w", encoding="utf-8", newline=newline) as output:
             output.write(file_contents)
 
 
@@ -221,8 +234,14 @@ def jinja_escaper(value: str) -> str:
     type=click.Path(resolve_path=True),
     default="users.yaml",
 )
+@click.option(
+    "--force-unix-eol",
+    is_flag=True,
+    default=False,
+    help="Force Unix end-of-line characters, otherwise use system default"
+)
 @click.pass_context
-def export_users(ctx: click.core.Context, path: str) -> None:
+def export_users(ctx: click.core.Context, path: str, force_unix_eol: bool=False) -> None:
     """
     Export users and their roles to a YAML file.
     """
@@ -234,7 +253,11 @@ def export_users(ctx: click.core.Context, path: str) -> None:
         {k: v for k, v in user.items() if k != "id"} for user in client.export_users()
     ]
 
-    with open(path, "w", encoding="utf-8") as output:
+    if force_unix_eol:
+        newline = "\n"
+    else:
+        newline = None
+    with open(path, "w", encoding="utf-8", newline=newline) as output:
         yaml.dump(users, output)
 
 
@@ -244,8 +267,14 @@ def export_users(ctx: click.core.Context, path: str) -> None:
     type=click.Path(resolve_path=True),
     default="roles.yaml",
 )
+@click.option(
+    "--force-unix-eol",
+    is_flag=True,
+    default=False,
+    help="Force Unix end-of-line characters, otherwise use system default"
+)
 @click.pass_context
-def export_roles(ctx: click.core.Context, path: str) -> None:
+def export_roles(ctx: click.core.Context, path: str, force_unix_eol: bool=False) -> None:
     """
     Export roles to a YAML file.
     """
@@ -253,7 +282,11 @@ def export_roles(ctx: click.core.Context, path: str) -> None:
     url = URL(ctx.obj["INSTANCE"])
     client = SupersetClient(url, auth)
 
-    with open(path, "w", encoding="utf-8") as output:
+    if force_unix_eol:
+        newline = "\n"
+    else:
+        newline = None
+    with open(path, "w", encoding="utf-8", newline=newline) as output:
         yaml.dump(list(client.export_roles()), output)
 
 
@@ -263,8 +296,14 @@ def export_roles(ctx: click.core.Context, path: str) -> None:
     type=click.Path(resolve_path=True),
     default="rls.yaml",
 )
+@click.option(
+    "--force-unix-eol",
+    is_flag=True,
+    default=False,
+    help="Force Unix end-of-line characters, otherwise use system default"
+)
 @click.pass_context
-def export_rls(ctx: click.core.Context, path: str) -> None:
+def export_rls(ctx: click.core.Context, path: str, force_unix_eol: bool=False) -> None:
     """
     Export RLS rules to a YAML file.
     """
@@ -272,7 +311,11 @@ def export_rls(ctx: click.core.Context, path: str) -> None:
     url = URL(ctx.obj["INSTANCE"])
     client = SupersetClient(url, auth)
 
-    with open(path, "w", encoding="utf-8") as output:
+    if force_unix_eol:
+        newline = "\n"
+    else:
+        newline = None
+    with open(path, "w", encoding="utf-8", newline=newline) as output:
         yaml.dump(list(client.export_rls()), output, sort_keys=False)
 
 
@@ -282,8 +325,14 @@ def export_rls(ctx: click.core.Context, path: str) -> None:
     type=click.Path(resolve_path=True),
     default="ownership.yaml",
 )
+@click.option(
+    "--force-unix-eol",
+    is_flag=True,
+    default=False,
+    help="Force Unix end-of-line characters, otherwise use system default"
+)
 @click.pass_context
-def export_ownership(ctx: click.core.Context, path: str) -> None:
+def export_ownership(ctx: click.core.Context, path: str, force_unix_eol: bool=False) -> None:
     """
     Export DBs/datasets/charts/dashboards ownership to a YAML file.
     """
@@ -302,5 +351,9 @@ def export_ownership(ctx: click.core.Context, path: str) -> None:
                 },
             )
 
-    with open(path, "w", encoding="utf-8") as output:
+    if force_unix_eol:
+        newline = "\n"
+    else:
+        newline = None
+    with open(path, "w", encoding="utf-8", newline=newline) as output:
         yaml.dump(dict(ownership), output)

--- a/tests/cli/superset/export_test.py
+++ b/tests/cli/superset/export_test.py
@@ -755,3 +755,77 @@ def test_export_resource_jinja_escaping_disabled_command(
             ),
         ],
     )
+
+
+def test_export_resource_force_unix_eol_command(
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
+) -> None:
+    """
+    Test the ``export_assets`` with ``--force-unix-eol`` command.
+    """
+    # root must exist for command to succeed
+    root = Path("/path/to/root")
+    fs.create_dir(root)
+
+    SupersetClient = mocker.patch("preset_cli.cli.superset.export.SupersetClient")
+    client = SupersetClient()
+    export_resource = mocker.patch("preset_cli.cli.superset.export.export_resource")
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        superset_cli,
+        [
+            "https://superset.example.org/",
+            "export",
+            "/path/to/root",
+            "--force-unix-eol",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    export_resource.assert_has_calls(
+        [
+            mock.call(
+                "database",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                False,
+                skip_related=True,
+                force_unix_eol=True,
+            ),
+            mock.call(
+                "dataset",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                False,
+                skip_related=True,
+                force_unix_eol=True,
+            ),
+            mock.call(
+                "chart",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                False,
+                skip_related=True,
+                force_unix_eol=True,
+            ),
+            mock.call(
+                "dashboard",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                False,
+                skip_related=True,
+                force_unix_eol=True,
+            ),
+        ],
+    )

--- a/tests/cli/superset/export_test.py
+++ b/tests/cli/superset/export_test.py
@@ -526,6 +526,51 @@ def test_export_users(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     ]
 
 
+def test_export_users_force_unix_eol_enable(
+    mocker: MockerFixture, fs: FakeFilesystem,
+) -> None:
+    """
+    Test the ``export_users`` command.
+    """
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+    SupersetClient = mocker.patch("preset_cli.cli.superset.export.SupersetClient")
+    client = SupersetClient()
+    client.export_users.return_value = [
+        {
+            "first_name": "admin",
+            "last_name": "admin",
+            "username": "admin",
+            "email": "admin@example.com",
+            "role": ["Admin"],
+        },
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        superset_cli,
+        [
+            "https://superset.example.org/",
+            "export-users",
+            "users.yaml",
+            "--force-unix-eol",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    with open("users.yaml", encoding="utf-8") as input_:
+        contents = yaml.load(input_, Loader=yaml.SafeLoader)
+    assert contents == [
+        {
+            "first_name": "admin",
+            "last_name": "admin",
+            "username": "admin",
+            "email": "admin@example.com",
+            "role": ["Admin"],
+        },
+    ]
+
+
 def test_export_roles(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     """
     Test the ``export_roles`` command.
@@ -544,6 +589,45 @@ def test_export_roles(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     result = runner.invoke(
         superset_cli,
         ["https://superset.example.org/", "export-roles", "roles.yaml"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    with open("roles.yaml", encoding="utf-8") as input_:
+        contents = yaml.load(input_, Loader=yaml.SafeLoader)
+    assert contents == [
+        {
+            "name": "Public",
+            "permissions": [],
+        },
+    ]
+
+
+def test_export_roles_force_unix_eol_enable(
+    mocker: MockerFixture, fs: FakeFilesystem,
+) -> None:
+    """
+    Test the ``export_roles`` command.
+    """
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+    SupersetClient = mocker.patch("preset_cli.cli.superset.export.SupersetClient")
+    client = SupersetClient()
+    client.export_roles.return_value = [
+        {
+            "name": "Public",
+            "permissions": [],
+        },
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        superset_cli,
+        [
+            "https://superset.example.org/",
+            "export-roles",
+            "roles.yaml",
+            "--force-unix-eol",
+        ],
         catch_exceptions=False,
     )
     assert result.exit_code == 0
@@ -600,6 +684,50 @@ def test_export_rls(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     ]
 
 
+def test_export_rls_force_unix_eol_enable(
+    mocker: MockerFixture, fs: FakeFilesystem,
+) -> None:
+    """
+    Test the ``export_rls`` command.
+    """
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+    SupersetClient = mocker.patch("preset_cli.cli.superset.export.SupersetClient")
+    client = SupersetClient()
+    client.export_rls.return_value = [
+        {
+            "clause": "client_id = 9",
+            "description": "This is a rule. There are many others like it, but this one is mine.",
+            "filter_type": "Regular",
+            "group_key": "department",
+            "name": "My rule",
+            "roles": ["Gamma"],
+            "tables": ["main.test_table"],
+        },
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        superset_cli,
+        ["https://superset.example.org/", "export-rls", "rls.yaml", "--force-unix-eol"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    with open("rls.yaml", encoding="utf-8") as input_:
+        contents = yaml.load(input_, Loader=yaml.SafeLoader)
+    assert contents == [
+        {
+            "clause": "client_id = 9",
+            "description": "This is a rule. There are many others like it, but this one is mine.",
+            "filter_type": "Regular",
+            "group_key": "department",
+            "name": "My rule",
+            "roles": ["Gamma"],
+            "tables": ["main.test_table"],
+        },
+    ]
+
+
 def test_export_ownership(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     """
     Test the ``export_ownership`` command.
@@ -623,6 +751,48 @@ def test_export_ownership(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     result = runner.invoke(
         superset_cli,
         ["https://superset.example.org/", "export-ownership"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    with open("ownership.yaml", encoding="utf-8") as input_:
+        contents = yaml.load(input_, Loader=yaml.SafeLoader)
+    assert contents == {
+        "chart": [
+            {
+                "name": "My chart",
+                "uuid": "e0d20af0-cef9-4bdb-80b4-745827f441bf",
+                "owners": ["adoe@example.com", "bdoe@example.com"],
+            },
+        ],
+    }
+
+
+def test_export_ownership_force_unix_eol_enable(
+    mocker: MockerFixture, fs: FakeFilesystem,
+) -> None:
+    """
+    Test the ``export_ownership`` command.
+    """
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+    SupersetClient = mocker.patch("preset_cli.cli.superset.export.SupersetClient")
+    client = SupersetClient()
+    client.export_ownership.side_effect = [
+        [],
+        [
+            {
+                "name": "My chart",
+                "uuid": UUID("e0d20af0-cef9-4bdb-80b4-745827f441bf"),
+                "owners": ["adoe@example.com", "bdoe@example.com"],
+            },
+        ],
+        [],
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        superset_cli,
+        ["https://superset.example.org/", "export-ownership", "--force-unix-eol"],
         catch_exceptions=False,
     )
     assert result.exit_code == 0
@@ -755,6 +925,49 @@ def test_export_resource_jinja_escaping_disabled_command(
             ),
         ],
     )
+
+
+def test_export_resource_force_unix_eol_enabled(
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
+    chart_export: BytesIO,
+) -> None:
+    """
+    Test ``export_resource`` with ``--disable-jinja-escaping``.
+    """
+    root = Path("/path/to/root")
+    fs.create_dir(root)
+
+    client = mocker.MagicMock()
+    client.export_zip.return_value = chart_export
+
+    # check that Jinja2 was not escaped
+    export_resource(
+        resource_name="dataset",
+        requested_ids=set(),
+        root=root,
+        client=client,
+        overwrite=False,
+        disable_jinja_escaping=True,
+        force_unix_eol=True,
+    )
+    with open(root / "datasets/gsheets/test.yaml", encoding="utf-8") as input_:
+        assert yaml.load(input_.read(), Loader=yaml.SafeLoader) == {
+            "table_name": "test",
+            "sql": """
+SELECT action, count(*) as times
+FROM logs
+{% if filter_values('action_type')|length %}
+    WHERE action is null
+    {% for action in filter_values('action_type') %}
+        or action = '{{ action }}'
+    {% endfor %}
+{% endif %}
+GROUP BY action""",
+        }
+
+    # metadata file should be ignored
+    assert not (root / "metadata.yaml").exists()
 
 
 def test_export_resource_force_unix_eol_command(

--- a/tests/cli/superset/export_test.py
+++ b/tests/cli/superset/export_test.py
@@ -120,6 +120,7 @@ def test_export_resource(
         client=client,
         overwrite=False,
         disable_jinja_escaping=False,
+        force_unix_eol=False,
     )
     with open(root / "databases/gsheets.yaml", encoding="utf-8") as input_:
         assert input_.read() == "database_name: GSheets\nsqlalchemy_uri: gsheets://\n"
@@ -132,6 +133,7 @@ def test_export_resource(
         client=client,
         overwrite=False,
         disable_jinja_escaping=False,
+        force_unix_eol=False,
     )
     with open(root / "datasets/gsheets/test.yaml", encoding="utf-8") as input_:
         assert yaml.load(input_.read(), Loader=yaml.SafeLoader) == {
@@ -156,6 +158,7 @@ GROUP BY action""",
         client=client,
         overwrite=False,
         disable_jinja_escaping=False,
+        force_unix_eol=False,
     )
     with open(root / "charts/test_01.yaml", encoding="utf-8") as input_:
         # load `query_context` as JSON to avoid
@@ -229,6 +232,7 @@ def test_export_resource_overwrite(
         client=client,
         overwrite=False,
         disable_jinja_escaping=False,
+        force_unix_eol=False,
     )
     with pytest.raises(Exception) as excinfo:
         export_resource(
@@ -238,6 +242,7 @@ def test_export_resource_overwrite(
             client=client,
             overwrite=False,
             disable_jinja_escaping=False,
+            force_unix_eol=False,
         )
     assert str(excinfo.value) == (
         "File already exists and ``--overwrite`` was not specified: "
@@ -251,6 +256,7 @@ def test_export_resource_overwrite(
         client=client,
         overwrite=True,
         disable_jinja_escaping=False,
+        force_unix_eol=False,
     )
 
 
@@ -284,6 +290,7 @@ def test_export_assets(mocker: MockerFixture, fs: FakeFilesystem) -> None:
                 False,
                 False,
                 skip_related=True,
+                force_unix_eol=False,
             ),
             mock.call(
                 "dataset",
@@ -293,6 +300,7 @@ def test_export_assets(mocker: MockerFixture, fs: FakeFilesystem) -> None:
                 False,
                 False,
                 skip_related=True,
+                force_unix_eol=False,
             ),
             mock.call(
                 "chart",
@@ -302,6 +310,7 @@ def test_export_assets(mocker: MockerFixture, fs: FakeFilesystem) -> None:
                 False,
                 False,
                 skip_related=True,
+                force_unix_eol=False,
             ),
             mock.call(
                 "dashboard",
@@ -311,6 +320,7 @@ def test_export_assets(mocker: MockerFixture, fs: FakeFilesystem) -> None:
                 False,
                 False,
                 skip_related=True,
+                force_unix_eol=False,
             ),
         ],
     )
@@ -352,6 +362,7 @@ def test_export_assets_by_id(mocker: MockerFixture, fs: FakeFilesystem) -> None:
                 False,
                 False,
                 skip_related=False,
+                force_unix_eol=False,
             ),
         ],
     )
@@ -395,6 +406,7 @@ def test_export_assets_by_type(mocker: MockerFixture, fs: FakeFilesystem) -> Non
                 False,
                 False,
                 skip_related=True,
+                force_unix_eol=False,
             ),
             mock.call(
                 "dashboard",
@@ -404,6 +416,7 @@ def test_export_assets_by_type(mocker: MockerFixture, fs: FakeFilesystem) -> Non
                 False,
                 False,
                 skip_related=True,
+                force_unix_eol=False,
             ),
         ],
     )
@@ -439,6 +452,7 @@ def test_export_with_custom_auth(mocker: MockerFixture, fs: FakeFilesystem) -> N
                 False,
                 False,
                 skip_related=True,
+                force_unix_eol=False,
             ),
             mock.call(
                 "dataset",
@@ -448,6 +462,7 @@ def test_export_with_custom_auth(mocker: MockerFixture, fs: FakeFilesystem) -> N
                 False,
                 False,
                 skip_related=True,
+                force_unix_eol=False,
             ),
             mock.call(
                 "chart",
@@ -457,6 +472,7 @@ def test_export_with_custom_auth(mocker: MockerFixture, fs: FakeFilesystem) -> N
                 False,
                 False,
                 skip_related=True,
+                force_unix_eol=False,
             ),
             mock.call(
                 "dashboard",
@@ -466,6 +482,7 @@ def test_export_with_custom_auth(mocker: MockerFixture, fs: FakeFilesystem) -> N
                 False,
                 False,
                 skip_related=True,
+                force_unix_eol=False,
             ),
         ],
     )
@@ -645,6 +662,7 @@ def test_export_resource_jinja_escaping_disabled(
         client=client,
         overwrite=False,
         disable_jinja_escaping=True,
+        force_unix_eol=False,
     )
     with open(root / "datasets/gsheets/test.yaml", encoding="utf-8") as input_:
         assert yaml.load(input_.read(), Loader=yaml.SafeLoader) == {
@@ -703,6 +721,7 @@ def test_export_resource_jinja_escaping_disabled_command(
                 False,
                 True,
                 skip_related=True,
+                force_unix_eol=False,
             ),
             mock.call(
                 "dataset",
@@ -712,6 +731,7 @@ def test_export_resource_jinja_escaping_disabled_command(
                 False,
                 True,
                 skip_related=True,
+                force_unix_eol=False,
             ),
             mock.call(
                 "chart",
@@ -721,6 +741,7 @@ def test_export_resource_jinja_escaping_disabled_command(
                 False,
                 True,
                 skip_related=True,
+                force_unix_eol=False,
             ),
             mock.call(
                 "dashboard",
@@ -730,6 +751,7 @@ def test_export_resource_jinja_escaping_disabled_command(
                 False,
                 True,
                 skip_related=True,
+                force_unix_eol=False,
             ),
         ],
     )

--- a/tests/cli/superset/export_test.py
+++ b/tests/cli/superset/export_test.py
@@ -1,7 +1,7 @@
 """
 Tests for the export commands.
 """
-# pylint: disable=redefined-outer-name, invalid-name, unused-argument
+# pylint: disable=redefined-outer-name, invalid-name, unused-argument, too-many-lines
 
 import json
 from io import BytesIO
@@ -527,7 +527,8 @@ def test_export_users(mocker: MockerFixture, fs: FakeFilesystem) -> None:
 
 
 def test_export_users_force_unix_eol_enable(
-    mocker: MockerFixture, fs: FakeFilesystem,
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
 ) -> None:
     """
     Test the ``export_users`` command.
@@ -604,7 +605,8 @@ def test_export_roles(mocker: MockerFixture, fs: FakeFilesystem) -> None:
 
 
 def test_export_roles_force_unix_eol_enable(
-    mocker: MockerFixture, fs: FakeFilesystem,
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
 ) -> None:
     """
     Test the ``export_roles`` command.
@@ -685,7 +687,8 @@ def test_export_rls(mocker: MockerFixture, fs: FakeFilesystem) -> None:
 
 
 def test_export_rls_force_unix_eol_enable(
-    mocker: MockerFixture, fs: FakeFilesystem,
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
 ) -> None:
     """
     Test the ``export_rls`` command.
@@ -769,7 +772,8 @@ def test_export_ownership(mocker: MockerFixture, fs: FakeFilesystem) -> None:
 
 
 def test_export_ownership_force_unix_eol_enable(
-    mocker: MockerFixture, fs: FakeFilesystem,
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
 ) -> None:
     """
     Test the ``export_ownership`` command.

--- a/tests/cli/superset/main_test.py
+++ b/tests/cli/superset/main_test.py
@@ -138,6 +138,8 @@ Commands:
 Options:
   --overwrite               Overwrite existing resources
   --disable-jinja-escaping  Disable Jinja template escaping
+  --force-unix-eol          Force Unix end-of-line characters, otherwise use
+                            system default
   --asset-type TEXT         Asset type
   --database-ids TEXT       Comma separated list of database IDs to export
   --dataset-ids TEXT        Comma separated list of dataset IDs to export


### PR DESCRIPTION
PR adds an optional argument to the CLI export commands to force Unix EOLs for the exported files.  This is intended to address issues when exporting into Windows environments where we have multiple developers using different OS. 