### PR TITLE
Adding ability to import dataset asset with no 'targets' field like filter divider

### DIFF
--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -280,13 +280,9 @@ def import_resources_individually(
                     continue
 
                 asset_configs = {path: config}
-                try:
-                    for uuid in get_related_uuids(config):
-                        asset_configs.update(related_configs[uuid])
-                except KeyError as err:
-                    _logger.debug(f"{err=}")
-                    # breakpoint()
-                    raise err
+                for uuid in get_related_uuids(config):
+                    asset_configs.update(related_configs[uuid])
+
                 _logger.info("Importing %s", path.relative_to("bundle"))
                 contents = {str(k): yaml.dump(v) for k, v in asset_configs.items()}
                 if path not in imported:
@@ -329,7 +325,7 @@ def get_dataset_filter_uuids(config: AssetConfig) -> Set[str]:
     """
     dataset_uuids = set()
     for filter_config in config["metadata"].get("native_filter_configuration", []):
-        for target in filter_config.get("targets", dict()):
+        for target in filter_config["targets"]:
             if uuid := target.get("datasetUuid"):
                 if uuid not in dataset_uuids:
                     dataset_uuids.add(uuid)

--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -329,7 +329,7 @@ def get_dataset_filter_uuids(config: AssetConfig) -> Set[str]:
     """
     dataset_uuids = set()
     for filter_config in config["metadata"].get("native_filter_configuration", []):
-        for target in filter_config.get("targets", []):  # ["targets"]:
+        for target in filter_config.get("targets", dict()):
             if uuid := target.get("datasetUuid"):
                 if uuid not in dataset_uuids:
                     dataset_uuids.add(uuid)

--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -325,7 +325,7 @@ def get_dataset_filter_uuids(config: AssetConfig) -> Set[str]:
     """
     dataset_uuids = set()
     for filter_config in config["metadata"].get("native_filter_configuration", []):
-        for target in filter_config.get("targets", dict()):
+        for target in filter_config.get("targets", {}):
             if uuid := target.get("datasetUuid"):
                 if uuid not in dataset_uuids:
                     dataset_uuids.add(uuid)
@@ -378,6 +378,7 @@ def import_resources(
     """
     Import a bundle of assets.
     """
+
     contents["bundle/metadata.yaml"] = yaml.dump(
         dict(
             version="1.0.0",

--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -325,7 +325,7 @@ def get_dataset_filter_uuids(config: AssetConfig) -> Set[str]:
     """
     dataset_uuids = set()
     for filter_config in config["metadata"].get("native_filter_configuration", []):
-        for target in filter_config["targets"]:
+        for target in filter_config.get("targets", dict()):
             if uuid := target.get("datasetUuid"):
                 if uuid not in dataset_uuids:
                     dataset_uuids.add(uuid)

--- a/tests/cli/superset/sync/native/command_test.py
+++ b/tests/cli/superset/sync/native/command_test.py
@@ -1,6 +1,7 @@
 """
 Tests for the native import command.
 """
+
 # pylint: disable=redefined-outer-name, invalid-name, too-many-lines
 
 import json
@@ -516,9 +517,9 @@ def test_native_external_url(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     )
     assert result.exit_code == 0
     database_config["external_url"] = "https://repo.example.com/databases/gsheets.yaml"
-    dataset_config[
-        "external_url"
-    ] = "https://repo.example.com/datasets/gsheets/test.yaml"
+    dataset_config["external_url"] = (
+        "https://repo.example.com/datasets/gsheets/test.yaml"
+    )
     contents = {
         "bundle/databases/gsheets.yaml": yaml.dump(database_config),
         "bundle/datasets/gsheets/test.yaml": yaml.dump(dataset_config),
@@ -817,6 +818,7 @@ def test_native_split(  # pylint: disable=too-many-locals
         },
         "uuid": "6",
     }
+
     dashboard_with_temporal_filter = {
         "dashboard_title": "Some dashboard",
         "is_managed_externally": False,
@@ -849,6 +851,45 @@ def test_native_split(  # pylint: disable=too-many-locals
         },
         "uuid": "6",
     }
+
+    dashboard_with_filter_divider_config = {
+        "dashboard_title": "Some dashboard",
+        "is_managed_externally": False,
+        "position": {},
+        "metadata": {
+            "native_filter_configuration": [
+                {
+                    "type": "NATIVE_FILTER",
+                    "targets": [
+                        {
+                            "column": "some_column",
+                            "datasetUuid": "5",
+                        },
+                    ],
+                },
+                {"type": "DIVIDER", "targets": {}},
+                {
+                    "type": "NATIVE_FILTER",
+                    "targets": [
+                        {
+                            "column": "other_column",
+                            "datasetUuid": "5",
+                        },
+                    ],
+                },
+                {
+                    "type": "NATIVE_FILTER",
+                    "targets": [
+                        {
+                            "column": "blah",
+                            "datasetUuid": "2",
+                        },
+                    ],
+                },
+            ],
+        },
+        "uuid": "7",
+    }
     fs.create_file(
         root / "databases/gsheets.yaml",
         contents=yaml.dump(database_config),
@@ -879,6 +920,10 @@ def test_native_split(  # pylint: disable=too-many-locals
     )
     fs.create_file(
         root / "dashboards/dashboard_deleted_dataset.yaml",
+        contents=yaml.dump(dashboard_deleted_dataset),
+    )
+    fs.create_file(
+        root / "dashboards/dashboard_with_filter_divider_config.yaml",
         contents=yaml.dump(dashboard_deleted_dataset),
     )
 
@@ -970,6 +1015,20 @@ def test_native_split(  # pylint: disable=too-many-locals
                 {
                     "bundle/dashboards/dashboard.yaml": yaml.dump(dashboard_config),
                     "bundle/charts/chart.yaml": yaml.dump(chart_config),
+                    "bundle/datasets/gsheets/test.yaml": yaml.dump(dataset_config),
+                    "bundle/databases/gsheets.yaml": yaml.dump(database_config),
+                },
+                client,
+                False,
+            ),
+            mock.call(
+                {
+                    "bundle/dashboards/dashboard_with_filter_divider_config.yaml": yaml.dump(
+                        dashboard_with_filter_divider_config,
+                    ),
+                    "bundle/datasets/gsheets/filter_test.yaml": yaml.dump(
+                        dataset_filter_config,
+                    ),
                     "bundle/datasets/gsheets/test.yaml": yaml.dump(dataset_config),
                     "bundle/databases/gsheets.yaml": yaml.dump(database_config),
                 },

--- a/tests/cli/superset/sync/native/command_test.py
+++ b/tests/cli/superset/sync/native/command_test.py
@@ -865,7 +865,6 @@ def test_native_split(  # pylint: disable=too-many-locals
         },
         "uuid": "6",
     }
-
     dashboard_with_temporal_filter = {
         "dashboard_title": "Some dashboard",
         "is_managed_externally": False,
@@ -915,24 +914,6 @@ def test_native_split(  # pylint: disable=too-many-locals
                     ],
                 },
                 {"type": "DIVIDER", "targets": {}},
-                {
-                    "type": "NATIVE_FILTER",
-                    "targets": [
-                        {
-                            "column": "other_column",
-                            "datasetUuid": "5",
-                        },
-                    ],
-                },
-                {
-                    "type": "NATIVE_FILTER",
-                    "targets": [
-                        {
-                            "column": "blah",
-                            "datasetUuid": "2",
-                        },
-                    ],
-                },
             ],
         },
         "uuid": "7",
@@ -971,7 +952,7 @@ def test_native_split(  # pylint: disable=too-many-locals
     )
     fs.create_file(
         root / "dashboards/dashboard_with_filter_divider_config.yaml",
-        contents=yaml.dump(dashboard_deleted_dataset),
+        contents=yaml.dump(dashboard_with_filter_divider_config),
     )
 
     SupersetClient = mocker.patch(
@@ -1076,13 +1057,13 @@ def test_native_split(  # pylint: disable=too-many-locals
                     "bundle/datasets/gsheets/filter_test.yaml": yaml.dump(
                         dataset_filter_config,
                     ),
-                    "bundle/datasets/gsheets/test.yaml": yaml.dump(dataset_config),
                     "bundle/databases/gsheets.yaml": yaml.dump(database_config),
                 },
                 client,
                 False,
             ),
         ],
+        any_order=True,
     )
 
 

--- a/tests/cli/superset/sync/native/command_test.py
+++ b/tests/cli/superset/sync/native/command_test.py
@@ -517,9 +517,9 @@ def test_native_external_url(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     )
     assert result.exit_code == 0
     database_config["external_url"] = "https://repo.example.com/databases/gsheets.yaml"
-    dataset_config["external_url"] = (
-        "https://repo.example.com/datasets/gsheets/test.yaml"
-    )
+    dataset_config[
+        "external_url"
+    ] = "https://repo.example.com/datasets/gsheets/test.yaml"
     contents = {
         "bundle/databases/gsheets.yaml": yaml.dump(database_config),
         "bundle/datasets/gsheets/test.yaml": yaml.dump(dataset_config),


### PR DESCRIPTION
Currently, importing a dashboard with filter dividers will break as the import of the dataset filters expects a 'targets' field in the yaml config file. However, a filter divider, which has no target, can still be imported if the 'targets' field defaults to an empty `dict`.