### PR TITLE
fix(dbt Cloud): Allow None on custom_branch_only field and update some endpoints to v3

### DIFF
--- a/src/preset_cli/api/clients/dbt.py
+++ b/src/preset_cli/api/clients/dbt.py
@@ -423,7 +423,7 @@ class TriggerSchema(PostelSchema):
     github_webhook = fields.Boolean(required=True)
     git_provider_webhook = fields.Boolean()
     schedule = fields.Boolean(required=True)
-    custom_branch_only = fields.Boolean()
+    custom_branch_only = fields.Boolean(allow_none=True)
 
 
 class SettingsSchema(PostelSchema):
@@ -724,7 +724,7 @@ class DBTClient:  # pylint: disable=too-few-public-methods
         """
         List all accounts.
         """
-        url = self.baseurl / "api/v2/accounts/"
+        url = self.baseurl / "api/v3/accounts/"
         _logger.debug("GET %s", url)
         response = self.session.get(url)
 
@@ -740,7 +740,7 @@ class DBTClient:  # pylint: disable=too-few-public-methods
         """
         List all projects.
         """
-        url = self.baseurl / "api/v2/accounts" / str(account_id) / "projects/"
+        url = self.baseurl / "api/v3/accounts" / str(account_id) / "projects/"
         _logger.debug("GET %s", url)
         response = self.session.get(url)
 


### PR DESCRIPTION
When loading information about jobs from a dbt Cloud project, it's possible that the `custom_branch_only` field (from the `TriggerSchema`) returns `None`. This PR adds supports for such scenario.

It also updates some endpoints to use [dbt Cloud v3 API](https://docs.getdbt.com/docs/dbt-cloud-apis/admin-cloud-api).