### PR TITLE
feat(import ownership): Continue on error + skip import failures

### DIFF
--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -1180,7 +1180,7 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
     def import_ownership(
         self,
         resource_name: str,
-        ownership: List[Dict[str, Any]],
+        ownership: Dict[str, Any],
     ) -> None:
         """
         Import ownership on resources.
@@ -1188,11 +1188,9 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
         user_ids = {user["email"]: user["id"] for user in self.export_users()}
         resource_ids = {str(v): k for k, v in self.get_uuids(resource_name).items()}
 
-        for item in ownership:
-            if item["uuid"] not in resource_ids:
-                continue
-            resource_id = resource_ids[item["uuid"]]
-            owner_ids = [user_ids[email] for email in item["owners"]]
+        if ownership["uuid"] in resource_ids:
+            resource_id = resource_ids[ownership["uuid"]]
+            owner_ids = [user_ids[email] for email in ownership["owners"]]
             self.update_resource(resource_name, resource_id, owners=owner_ids)
 
     def update_role(self, role_id: int, **kwargs: Any) -> None:

--- a/src/preset_cli/cli/superset/import_.py
+++ b/src/preset_cli/cli/superset/import_.py
@@ -7,6 +7,12 @@ import yaml
 from yarl import URL
 
 from preset_cli.api.clients.superset import SupersetClient
+from preset_cli.cli.superset.lib import (
+    add_asset_to_log_dict,
+    clean_logs,
+    get_logs,
+    write_logs_to_file,
+)
 
 
 @click.command()
@@ -57,8 +63,19 @@ def import_roles(ctx: click.core.Context, path: str) -> None:
     type=click.Path(resolve_path=True),
     default="ownership.yaml",
 )
+@click.option(
+    "--continue-on-error",
+    "-c",
+    is_flag=True,
+    default=False,
+    help="Continue the import if an asset fails to import ownership",
+)
 @click.pass_context
-def import_ownership(ctx: click.core.Context, path: str) -> None:
+def import_ownership(
+    ctx: click.core.Context,
+    path: str,
+    continue_on_error: bool = False,
+) -> None:
     """
     Import resource ownership from a YAML file.
     """
@@ -66,7 +83,53 @@ def import_ownership(ctx: click.core.Context, path: str) -> None:
     url = URL(ctx.obj["INSTANCE"])
     client = SupersetClient(url, auth)
 
+    logs = get_logs()
+    failed_assets = (
+        {log["uuid"] for log in logs["assets"] if log["status"] == "FAILED"}
+        if logs.get("assets")
+        else set()
+    )
+
+    # Remove FAILED logs to re-try them
+    if "ownership" in logs:
+        logs["ownership"] = [
+            asset for asset in logs["ownership"] if asset["status"] != "FAILED"
+        ]
+    else:
+        logs["ownership"] = []
+
+    assets_to_skip = {log["uuid"] for log in logs["ownership"]} | failed_assets
+
     with open(path, encoding="utf-8") as input_:
         config = yaml.load(input_, Loader=yaml.SafeLoader)
-        for resource_name, ownership in config.items():
-            client.import_ownership(resource_name, ownership)
+        for resource_name, resources in config.items():
+            for ownership in resources:
+                if ownership["uuid"] not in assets_to_skip:
+                    try:
+                        client.import_ownership(resource_name, ownership)
+                    except Exception:  # pylint: disable=broad-except
+                        if not continue_on_error:
+                            write_logs_to_file(logs)
+                            raise
+
+                        add_asset_to_log_dict(
+                            "ownership",
+                            logs,
+                            "FAILED",
+                            ownership["uuid"],
+                        )
+                        continue
+
+                    add_asset_to_log_dict(
+                        "ownership",
+                        logs,
+                        "SUCCESS",
+                        ownership["uuid"],
+                    )
+
+    if not continue_on_error or not any(
+        log["status"] == "FAILED" for log in logs["ownership"]
+    ):
+        clean_logs("ownership", logs)
+    else:
+        write_logs_to_file(logs)

--- a/src/preset_cli/cli/superset/lib.py
+++ b/src/preset_cli/cli/superset/lib.py
@@ -1,0 +1,77 @@
+"""
+Helper functions for the Superset commands
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Set
+
+import yaml
+
+LOG_FILE_PATH = Path("progress.log")
+
+
+def get_logs() -> dict[str, Any]:
+    """
+    Returns the content of the progress log file.
+
+    If the log file does not exist, an empty one is created.
+    """
+    if not LOG_FILE_PATH.exists():
+        LOG_FILE_PATH.touch()
+
+    with open(LOG_FILE_PATH, "r", encoding="utf-8") as log_file:
+        logs = yaml.load(log_file, Loader=yaml.SafeLoader) or {}
+
+    return logs
+
+
+def add_asset_to_log_dict(  # pylint: disable=too-many-arguments
+    log_type: str,
+    logs: Dict[str, Any],
+    status: str,
+    asset_uuid: str,
+    asset_path: Path | None = None,
+    set_: Set[Path] | None = None,
+) -> None:
+    """
+    Adds an asset log entry to the logs dictionary and optionally to a set of skipped items.
+
+    The `logs` dictionary will is written to a file.
+    """
+    log_entry = {
+        "status": status,
+        "uuid": asset_uuid,
+    }
+    if asset_path is not None:
+        log_entry["path"] = str(asset_path)
+
+    if log_type in logs:
+        logs[log_type].append(log_entry)
+    else:
+        logs[log_type] = [log_entry]
+
+    if set_ is not None and asset_path:
+        set_.add(asset_path)
+
+
+def write_logs_to_file(logs: Dict[str, Any]) -> None:
+    """
+    Writes logs list to .log file.
+    """
+    with open(LOG_FILE_PATH, "w", encoding="utf-8") as log_file:
+        yaml.dump(logs, log_file)
+
+
+def clean_logs(log_type: str, logs: Dict[str, Any]) -> None:
+    """
+    Cleans the progress log file for the specific log type.
+
+    If there are no other log types, the file is deleted.
+    """
+    logs.pop(log_type, None)
+    if logs:
+        write_logs_to_file(logs)
+    else:
+        LOG_FILE_PATH.unlink()

--- a/tests/api/clients/superset_test.py
+++ b/tests/api/clients/superset_test.py
@@ -3492,18 +3492,19 @@ def test_import_ownership(mocker: MockerFixture, requests_mock: Mocker) -> None:
     client = SupersetClient("https://superset.example.org/", auth)
     client.import_ownership(
         "dataset",
-        [
-            {
-                "name": "test_table",
-                "owners": ["admin@example.com", "adoe@example.com"],
-                "uuid": "e0d20af0-cef9-4bdb-80b4-745827f441bf",
-            },
-            {
-                "name": "another_table",
-                "owners": ["admin@example.com", "adoe@example.com"],
-                "uuid": "1192072c-4bee-4535-b8ee-e9f5fc4eb6a2",
-            },
-        ],
+        {
+            "name": "test_table",
+            "owners": ["admin@example.com", "adoe@example.com"],
+            "uuid": "e0d20af0-cef9-4bdb-80b4-745827f441bf",
+        },
+    )
+    client.import_ownership(
+        "dataset",
+        {
+            "name": "another_table",
+            "owners": ["admin@example.com", "adoe@example.com"],
+            "uuid": "1192072c-4bee-4535-b8ee-e9f5fc4eb6a2",
+        },
     )
 
     assert requests_mock.last_request.json() == {"owners": [1, 2]}

--- a/tests/cli/superset/import_test.py
+++ b/tests/cli/superset/import_test.py
@@ -4,6 +4,10 @@ Tests for the import commands.
 
 # pylint: disable=invalid-name
 
+from pathlib import Path
+from unittest import mock
+
+import pytest
 import yaml
 from click.testing import CliRunner
 from pyfakefs.fake_filesystem import FakeFilesystem
@@ -75,6 +79,7 @@ def test_import_ownership(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     """
     mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
     SupersetClient = mocker.patch("preset_cli.cli.superset.import_.SupersetClient")
+    mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", Path("progress.log"))
     client = SupersetClient()
     ownership = {
         "dataset": [
@@ -95,4 +100,241 @@ def test_import_ownership(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     )
     assert result.exit_code == 0
 
-    client.import_ownership.assert_called_with("dataset", ownership["dataset"])
+    client.import_ownership.assert_called_with("dataset", ownership["dataset"][0])
+
+
+def test_import_ownership_progress_log(
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
+) -> None:
+    """
+    Test the ``import_ownership`` command with an existing log file.
+    """
+    logs_content = {
+        "assets": [
+            {
+                "path": "/path/to/root/first_path",
+                "status": "SUCCESS",
+                "uuid": "uuid1",
+            },
+            {
+                "path": "/path/to/root/second_path",
+                "status": "FAILED",
+                "uuid": "uuid2",
+            },
+        ],
+        "ownership": [
+            {
+                "status": "SUCCESS",
+                "uuid": "uuid3",
+            },
+            {
+                "status": "FAILED",
+                "uuid": "uuid4",
+            },
+        ],
+    }
+    fs.create_file("progress.log", contents=yaml.dump(logs_content))
+    mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", Path("progress.log"))
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+    SupersetClient = mocker.patch("preset_cli.cli.superset.import_.SupersetClient")
+    client = SupersetClient()
+    ownership = {
+        "dataset": [
+            {
+                "name": "test_table",
+                "owners": ["admin@example.com"],
+                "uuid": "uuid1",
+            },
+            {
+                "name": "other_table",
+                "owners": ["admin@example.com"],
+                "uuid": "uuid2",
+            },
+            {
+                "name": "yet_another_table",
+                "owners": ["admin@example.com"],
+                "uuid": "uuid3",
+            },
+            {
+                "name": "just_another_test_table",
+                "owners": ["admin@example.com"],
+                "uuid": "uuid4",
+            },
+            {
+                "name": "last_table",
+                "owners": ["admin@example.com"],
+                "uuid": "uuid5",
+            },
+        ],
+    }
+    fs.create_file("ownership.yaml", contents=yaml.dump(ownership))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        superset_cli,
+        ["https://superset.example.org/", "import-ownership"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    # Should skip `uuid2` as its import failed. Should also skip `uuid3`
+    # because its ownership was sucessfully imported, but retry `uuid4`.
+    client.import_ownership.assert_has_calls(
+        [
+            mock.call("dataset", ownership["dataset"][0]),
+            mock.call("dataset", ownership["dataset"][3]),
+            mock.call("dataset", ownership["dataset"][4]),
+        ],
+    )
+
+
+def test_import_ownership_failure(mocker: MockerFixture, fs: FakeFilesystem) -> None:
+    """
+    Test the ``import_ownership`` command when a failure happens without
+    the ``continue-on-error`` flag.
+    """
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+    SupersetClient = mocker.patch("preset_cli.cli.superset.import_.SupersetClient")
+    mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", Path("progress.log"))
+    client = SupersetClient()
+    ownership = {
+        "dataset": [
+            {
+                "name": "test_table",
+                "owners": ["admin@example.com"],
+                "uuid": "uuid1",
+            },
+            {
+                "name": "test_table_two",
+                "owners": ["admin@example.com"],
+                "uuid": "uuid2",
+            },
+        ],
+    }
+    fs.create_file("ownership.yaml", contents=yaml.dump(ownership))
+    client.import_ownership.side_effect = [
+        None,
+        Exception("An error occurred!"),
+    ]
+
+    assert not Path("progress.log").exists()
+
+    runner = CliRunner()
+    with pytest.raises(Exception):
+        runner.invoke(
+            superset_cli,
+            ["https://superset.example.org/", "import-ownership"],
+            catch_exceptions=False,
+        )
+
+    assert Path("progress.log").exists()
+    with open("progress.log", encoding="utf-8") as log:
+        content = yaml.load(log, Loader=yaml.SafeLoader)
+
+    assert content == {
+        "ownership": [
+            {
+                "uuid": "uuid1",
+                "status": "SUCCESS",
+            },
+        ],
+    }
+
+
+def test_import_ownership_failure_continue(
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
+) -> None:
+    """
+    Test the ``import_ownership`` command when a failure happens
+    with the ``continue-on-error`` flag.
+    """
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+    SupersetClient = mocker.patch("preset_cli.cli.superset.import_.SupersetClient")
+    mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", Path("progress.log"))
+    client = SupersetClient()
+    ownership = {
+        "dataset": [
+            {
+                "name": "test_table",
+                "owners": ["admin@example.com"],
+                "uuid": "uuid1",
+            },
+            {
+                "name": "test_table_two",
+                "owners": ["admin@example.com"],
+                "uuid": "uuid2",
+            },
+        ],
+    }
+    fs.create_file("ownership.yaml", contents=yaml.dump(ownership))
+    client.import_ownership.side_effect = [
+        Exception("An error occurred!"),
+        None,
+    ]
+
+    assert not Path("progress.log").exists()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        superset_cli,
+        ["https://superset.example.org/", "import-ownership", "--continue-on-error"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    assert Path("progress.log").exists()
+    with open("progress.log", encoding="utf-8") as log:
+        content = yaml.load(log, Loader=yaml.SafeLoader)
+
+    assert content == {
+        "ownership": [
+            {
+                "uuid": "uuid1",
+                "status": "FAILED",
+            },
+            {
+                "uuid": "uuid2",
+                "status": "SUCCESS",
+            },
+        ],
+    }
+
+
+def test_import_ownership_continue_no_errors(
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
+) -> None:
+    """
+    Test the ``import_ownership`` command with the ``continue-on-error`` flag.
+    """
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+    mocker.patch("preset_cli.cli.superset.import_.SupersetClient")
+    mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", Path("progress.log"))
+    ownership = {
+        "dataset": [
+            {
+                "name": "test_table",
+                "owners": ["admin@example.com"],
+                "uuid": "uuid1",
+            },
+            {
+                "name": "test_table_two",
+                "owners": ["admin@example.com"],
+                "uuid": "uuid2",
+            },
+        ],
+    }
+    fs.create_file("ownership.yaml", contents=yaml.dump(ownership))
+
+    assert not Path("progress.log").exists()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        superset_cli,
+        ["https://superset.example.org/", "import-ownership", "--continue-on-error"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert not Path("progress.log").exists()

--- a/tests/cli/superset/lib_test.py
+++ b/tests/cli/superset/lib_test.py
@@ -1,0 +1,270 @@
+"""
+Tests for ``preset_cli.cli.superset.lib``.
+"""
+# pylint: disable=unused-argument, invalid-name
+
+from pathlib import Path
+
+import yaml
+from pyfakefs.fake_filesystem import FakeFilesystem
+from pytest_mock import MockerFixture
+
+from preset_cli.cli.superset.lib import (
+    add_asset_to_log_dict,
+    clean_logs,
+    get_logs,
+    write_logs_to_file,
+)
+
+
+def test_get_logs_new_file(mocker: MockerFixture, fs: FakeFilesystem) -> None:
+    """
+    Test the ``get_logs`` helper when the log file does not exist.
+    """
+    mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", Path("progress.log"))
+    assert get_logs() == {}
+
+
+def test_get_logs_existing_file(mocker: MockerFixture, fs: FakeFilesystem) -> None:
+    """
+    Test the ``get_logs`` helper when the log file does not exist.
+    """
+    root = Path("/path/to/root")
+    fs.create_dir(root)
+
+    logs_content = {
+        "assets": [
+            {
+                "path": "/path/to/root/first_path",
+                "status": "SUCCESS",
+                "uuid": "uuid1",
+            },
+        ],
+        "ownership": [
+            {
+                "status": "SUCCESS",
+                "uuid": "uuid2",
+            },
+        ],
+    }
+    fs.create_file(
+        root / "progress.log",
+        contents=yaml.dump(logs_content),
+    )
+    mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", root / "progress.log")
+
+    assert get_logs() == logs_content
+
+
+def test_add_asset_to_log_dict_asset_import() -> None:
+    """
+    Test the ``add_asset_to_log_dict`` helper when passing asset logs.
+    """
+    logs = {
+        "assets": [
+            {
+                "path": "/path/to/root/first_path",
+                "status": "SUCCESS",
+                "uuid": "uuid1",
+            },
+        ],
+    }
+    skip = {Path("/path/to/root/first_path")}
+    add_asset_to_log_dict(
+        "assets",
+        logs,
+        "FAILED",
+        "uuid2",
+        asset_path=Path("/path/to/root/second_path"),
+        set_=skip,
+    )
+
+    assert logs == {
+        "assets": [
+            {
+                "path": "/path/to/root/first_path",
+                "status": "SUCCESS",
+                "uuid": "uuid1",
+            },
+            {
+                "path": "/path/to/root/second_path",
+                "status": "FAILED",
+                "uuid": "uuid2",
+            },
+        ],
+    }
+    assert skip == {Path("/path/to/root/first_path"), Path("/path/to/root/second_path")}
+
+    logs = {"assets": []}
+    skip = set()
+    add_asset_to_log_dict(
+        "assets",
+        logs,
+        "SUCCESS",
+        "uuid3",
+        asset_path=Path("/path/to/root/third_path"),
+        set_=skip,
+    )
+
+    assert logs == {
+        "assets": [
+            {
+                "path": "/path/to/root/third_path",
+                "status": "SUCCESS",
+                "uuid": "uuid3",
+            },
+        ],
+    }
+    assert skip == {Path("/path/to/root/third_path")}
+
+
+def test_add_asset_to_log_dict_ownership_import() -> None:
+    """
+    Test the ``add_asset_to_log_dict`` helper when passing ownership logs.
+    """
+    logs = {
+        "assets": [
+            {
+                "path": "/path/to/root/first_path",
+                "status": "SUCCESS",
+                "uuid": "uuid1",
+            },
+        ],
+    }
+    add_asset_to_log_dict(
+        "ownership",
+        logs,
+        "FAILED",
+        "uuid2",
+    )
+
+    assert logs == {
+        "assets": [
+            {
+                "path": "/path/to/root/first_path",
+                "status": "SUCCESS",
+                "uuid": "uuid1",
+            },
+        ],
+        "ownership": [
+            {
+                "status": "FAILED",
+                "uuid": "uuid2",
+            },
+        ],
+    }
+
+
+def test_write_logs_to_file(mocker: MockerFixture, fs: FakeFilesystem) -> None:
+    """
+    Test the ``write_logs_to_file`` helper.
+    """
+    root = Path("/path/to/root")
+    fs.create_dir(root)
+    fs.create_file(
+        root / "progress.log",
+        contents=yaml.dump(
+            {
+                "assets": [
+                    {
+                        "path": "/path/to/root/first_path",
+                        "status": "SUCCESS",
+                        "uuid": "uuid1",
+                    },
+                ],
+            },
+        ),
+    )
+    mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", root / "progress.log")
+
+    new_logs = {
+        "assets": [
+            {
+                "path": "/path/to/root/second_path",
+                "status": "SUCCESS",
+                "uuid": "uuid2",
+            },
+            {
+                "path": "/path/to/root/third_path",
+                "status": "SUCCESS",
+                "uuid": "uuid3",
+            },
+        ],
+        "ownership": [
+            {
+                "status": "SUCCESS",
+                "uuid": "uuid4",
+            },
+        ],
+    }
+
+    write_logs_to_file(new_logs)
+
+    with open(root / "progress.log", encoding="utf-8") as file:
+        content = yaml.load(file, Loader=yaml.SafeLoader)
+
+    assert content == new_logs
+
+
+def test_clean_logs_delete_file(mocker: MockerFixture, fs: FakeFilesystem) -> None:
+    """
+    Test the ``clean_logs`` helper when the log file should be deleted.
+    """
+    root = Path("/path/to/root")
+    logs_path = root / "progress.log"
+    mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", logs_path)
+    fs.create_dir(root)
+    logs = {
+        "assets": [
+            {
+                "path": "/path/to/root/first_path",
+                "status": "SUCCESS",
+                "uuid": "uuid1",
+            },
+        ],
+    }
+    fs.create_file(
+        root / "progress.log",
+        contents=yaml.dump(logs),
+    )
+    assert logs_path.exists()
+
+    clean_logs("assets", logs)
+    assert not logs_path.exists()
+
+
+def test_clean_logs_keep_file(mocker: MockerFixture, fs: FakeFilesystem) -> None:
+    """
+    Test the ``clean_logs`` helper when the log file should be kept.
+    """
+    root = Path("/path/to/root")
+    logs_path = root / "progress.log"
+    mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", logs_path)
+    fs.create_dir(root)
+    logs = {
+        "assets": [
+            {
+                "path": "/path/to/root/first_path",
+                "status": "SUCCESS",
+                "uuid": "uuid1",
+            },
+        ],
+        "ownership": [
+            {
+                "status": "SUCCESS",
+                "uuid": "uuid2",
+            },
+        ],
+    }
+    fs.create_file(
+        root / "progress.log",
+        contents=yaml.dump(logs),
+    )
+    assert logs_path.exists()
+
+    clean_logs("assets", logs)
+
+    with open(logs_path, encoding="utf-8") as log:
+        content = yaml.load(log, Loader=yaml.SafeLoader)
+
+    assert content == {"ownership": [{"status": "SUCCESS", "uuid": "uuid2"}]}


### PR DESCRIPTION
https://github.com/preset-io/backend-sdk/pull/328 added the ability to complete an import if errors happen. This PR extends this logic to the ``import-ownership`` command:
* If a failure happens, it gets logged and the import continues.
* It also skips any asset that was failed to import with the ``import-assets`` command.

Some of the logic is redundant to both commands, so it got moved to a new ``lib.py`` file. 