### PR TITLE
feat(dbt sync): Sync calculated columns from dbt

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -238,12 +238,13 @@ def compute_columns(
     return final_dataset_columns
 
 
-def compute_columns_metadata(
+def compute_columns_metadata(  # pylint: disable=too-many-branches, too-many-arguments  # noqa: C901
     dbt_columns: List[Any],
     dataset_columns: List[Any],
     reload_columns: bool,
     merge_metadata: bool,
-    column_defaults: Dict[str, Any] | None = None,
+    column_defaults: Dict[str, Any],
+    dbt_calc_columns: List[Dict[str, Any]],
 ) -> List[Any]:
     """
     Adds dbt metadata to dataset columns.
@@ -267,12 +268,34 @@ def compute_columns_metadata(
             dict_merge(final_column, dbt_metadata[column])
             dbt_metadata[column] = final_column
 
+    dbt_calc_columns_ = {c["column_name"]: c for c in dbt_calc_columns}
+
+    if column_defaults:
+        for column, definition in dbt_calc_columns_.items():
+            final_column = copy.deepcopy(column_defaults)
+            dict_merge(final_column, definition)
+            dbt_calc_columns_[column] = final_column
+    if reload_columns and dbt_calc_columns_:
+        dataset_columns = [
+            column
+            for column in dataset_columns
+            if not column.get("expression")
+            or column["column_name"] in dbt_calc_columns_
+        ]
+
     for column in dataset_columns:
         name = column["column_name"]
+        # regular column
         if name in dbt_metadata:
             for key, value in dbt_metadata[name].items():
                 if reload_columns or merge_metadata or not column.get(key):
                     column[key] = value
+        # calculated column
+        elif name in dbt_calc_columns_:
+            for key, value in dbt_calc_columns_[name].items():
+                if reload_columns or merge_metadata or not column.get(key):
+                    column[key] = value
+            del dbt_calc_columns_[name]
         elif column_defaults and (reload_columns or merge_metadata):
             for key, value in column_defaults.items():
                 column[key] = value
@@ -284,6 +307,11 @@ def compute_columns_metadata(
         # https://github.com/preset-io/backend-sdk/issues/163
         if "is_active" in column and column["is_active"] is None:
             del column["is_active"]
+
+    # Add new calc columns to list
+    if dbt_calc_columns_:
+        for definition in dbt_calc_columns_.values():
+            dataset_columns.append(definition)
 
     return dataset_columns
 
@@ -384,6 +412,11 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-arguments
                 failed_datasets.append(model["unique_id"])
                 continue
 
+        # get calculated columns from model
+        calculated_columns = (
+            model.get("meta", {}).get("superset", {}).pop("calculated_columns", [])
+        )
+
         # compute update payload
         update = compute_dataset_metadata(
             model,
@@ -403,14 +436,15 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-arguments
             continue
 
         # update column metadata
-        if dbt_columns := model.get("columns"):
+        if (dbt_columns := model.get("columns")) or calculated_columns:
             current_dataset_columns = client.get_dataset(dataset["id"])["columns"]
             dataset_columns = compute_columns_metadata(
                 dbt_columns,
                 current_dataset_columns,
                 reload_columns,
                 merge_metadata,
-                column_defaults=default_configs.get("columns", {}),
+                default_configs.get("columns", {}),
+                calculated_columns,
             )
             try:
                 client.update_dataset(

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -1981,7 +1981,7 @@ def test_compute_columns_metadata_with_calc_columns_preserve_metadata() -> None:
 def test_compute_columns_metadata_with_calc_columns_default_configs() -> None:
     """
     Test the ``compute_columns_metadata`` helper with calculated columns
-    set in dbt and sync set to merge metadata.
+    set in dbt and sync set to merge metadata with default column configs.
     """
     dbt_columns = [{"name": "id"}]
     dbt_calc_columns = [

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -383,7 +383,8 @@ def test_sync_datasets_custom_certification(mocker: MockerFixture) -> None:
         client.get_dataset()["columns"],
         True,
         False,
-        column_defaults={},
+        {},
+        [],
     )
     compute_columns_mock.assert_not_called()
     compute_dataset_metadata_mock.assert_called_with(
@@ -538,7 +539,8 @@ def test_sync_datasets_external_url_disallow_edits(mocker: MockerFixture) -> Non
         client.get_dataset()["columns"],
         True,
         False,
-        column_defaults={},
+        {},
+        [],
     )
     compute_columns_mock.assert_not_called()
     compute_dataset_metadata_mock.assert_called_with(
@@ -614,7 +616,8 @@ def test_sync_datasets_preserve_metadata(mocker: MockerFixture) -> None:
         client.get_dataset()["columns"],
         False,
         False,
-        column_defaults={},
+        {},
+        [],
     )
     compute_columns_mock.assert_called_with(
         get_or_create_dataset_mock()["columns"],
@@ -695,7 +698,8 @@ def test_sync_datasets_merge_metadata(mocker: MockerFixture) -> None:
         client.get_dataset()["columns"],
         False,
         True,
-        column_defaults={},
+        {},
+        [],
     )
     compute_columns_mock.assert_called_with(
         get_or_create_dataset_mock()["columns"],
@@ -1450,6 +1454,8 @@ def test_compute_columns_metadata_with_reload_no_merge() -> None:
         dataset_columns,
         True,
         False,
+        {},
+        [],
     )
 
     final = dataset_columns.copy()
@@ -1472,6 +1478,8 @@ def test_compute_columns_metadata_without_reload_with_merge() -> None:
         dataset_columns,
         False,
         True,
+        {},
+        [],
     )
 
     final = dataset_columns.copy()
@@ -1494,6 +1502,8 @@ def test_compute_columns_metadata_without_reload_and_merge() -> None:
         dataset_columns,
         False,
         False,
+        {},
+        [],
     )
     assert result == dataset_columns
 
@@ -1510,6 +1520,8 @@ def test_compute_columns_metadata_without_reload_and_merge_other() -> None:
         modified_columns,
         False,
         False,
+        {},
+        [],
     )
     modified_columns[1]["description"] = models[0]["columns"][0]["description"]
     assert result == modified_columns
@@ -1537,6 +1549,8 @@ def test_compute_columns_metadata_dbt_column_meta() -> None:
         dataset_columns,
         False,
         False,
+        {},
+        [],
     )
     expected = dataset_columns.copy()
     expected[1]["groupby"] = True
@@ -1634,7 +1648,8 @@ def test_compute_columns_metadata_with_default_configs() -> None:
         dataset_columns,
         True,
         False,
-        column_defaults=default_column_config,
+        default_column_config,
+        [],
     )
     assert result == expected
 
@@ -1643,9 +1658,422 @@ def test_compute_columns_metadata_with_default_configs() -> None:
         dataset_columns,
         False,
         True,
-        column_defaults=default_column_config,
+        default_column_config,
+        [],
     )
     assert result == expected
+
+
+def test_compute_columns_metadata_with_calc_columns() -> None:
+    """
+    Test the ``compute_columns_metadata`` helper with calculated columns
+    set in dbt.
+    """
+    dbt_columns = [{"name": "id", "description": "Primary key"}]
+    dbt_calc_columns = [
+        {
+            "column_name": "dbt_calc_column",
+            "expression": "id + 2",
+            "verbose_name": None,
+        },
+    ]
+    dataset_columns = [
+        {
+            "advanced_data_type": None,
+            "changed_on": "2024-01-23T20:29:33.945074",
+            "column_name": "calc_column",
+            "created_on": "2024-01-23T20:29:33.945070",
+            "description": None,
+            "expression": "id + 1",
+            "extra": "{}",
+            "filterable": True,
+            "groupby": True,
+            "id": 1,
+            "is_active": True,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": None,
+            "type_generic": None,
+            "uuid": "5b0dc14a-8c1a-4fcb-8791-3a955d8609d3",
+            "verbose_name": None,
+        },
+        {
+            "advanced_data_type": None,
+            "changed_on": "2024-01-03T13:30:19.139128",
+            "column_name": "id",
+            "created_on": "2021-12-22T16:59:38.825689",
+            "description": "Description for ID",
+            "expression": None,
+            "extra": "{}",
+            "filterable": True,
+            "groupby": False,
+            "id": 2,
+            "is_active": None,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": "INTEGER",
+            "type_generic": None,
+            "uuid": "a2952680-2671-4a97-b608-3483cf7f11d2",
+            "verbose_name": None,
+        },
+    ]
+
+    result = compute_columns_metadata(
+        dbt_columns,
+        dataset_columns,
+        True,
+        False,
+        {},
+        dbt_calc_columns,
+    )
+    assert result == [
+        {
+            "advanced_data_type": None,
+            "column_name": "id",
+            "description": "Primary key",
+            "expression": None,
+            "extra": "{}",
+            "filterable": True,
+            "groupby": False,
+            "id": 2,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": "INTEGER",
+            "uuid": "a2952680-2671-4a97-b608-3483cf7f11d2",
+            "verbose_name": "id",
+        },
+        {
+            "column_name": "dbt_calc_column",
+            "expression": "id + 2",
+            "verbose_name": None,
+        },
+    ]
+
+
+def test_compute_columns_metadata_with_calc_columns_merge_metadata() -> None:
+    """
+    Test the ``compute_columns_metadata`` helper with calculated columns
+    set in dbt and sync set to merge metadata.
+    """
+    dbt_columns = [{"name": "id", "description": "Primary key"}]
+    dbt_calc_columns = [
+        {
+            "column_name": "calc_column",
+            "expression": "id + 2",
+            "verbose_name": None,
+        },
+    ]
+    dataset_columns = [
+        {
+            "advanced_data_type": None,
+            "changed_on": "2024-01-23T20:29:33.945074",
+            "column_name": "calc_column",
+            "created_on": "2024-01-23T20:29:33.945070",
+            "description": None,
+            "expression": "id + 1",
+            "extra": "{}",
+            "filterable": True,
+            "groupby": True,
+            "id": 1,
+            "is_active": True,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": None,
+            "type_generic": None,
+            "uuid": "5b0dc14a-8c1a-4fcb-8791-3a955d8609d3",
+            "verbose_name": "My verbose name",
+        },
+        {
+            "advanced_data_type": None,
+            "changed_on": "2024-01-23T20:29:33.945074",
+            "column_name": "other_calc_column",
+            "created_on": "2024-01-23T20:29:33.945070",
+            "description": None,
+            "expression": "id * 5",
+            "extra": "{}",
+            "filterable": True,
+            "groupby": True,
+            "id": 2,
+            "is_active": True,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": None,
+            "type_generic": None,
+            "uuid": "5b0dc14a-8c1a-4fcb-8791-3a955d8609d3",
+            "verbose_name": "My verbose name",
+        },
+        {
+            "advanced_data_type": None,
+            "changed_on": "2024-01-03T13:30:19.139128",
+            "column_name": "id",
+            "created_on": "2021-12-22T16:59:38.825689",
+            "description": "Description for ID",
+            "expression": None,
+            "extra": "{}",
+            "filterable": True,
+            "groupby": False,
+            "id": 3,
+            "is_active": None,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": "INTEGER",
+            "type_generic": None,
+            "uuid": "a2952680-2671-4a97-b608-3483cf7f11d2",
+            "verbose_name": None,
+        },
+    ]
+
+    result = compute_columns_metadata(
+        dbt_columns,
+        dataset_columns,
+        False,
+        True,
+        {},
+        dbt_calc_columns,
+    )
+    assert result == [
+        {
+            "advanced_data_type": None,
+            "column_name": "calc_column",
+            "description": None,
+            "expression": "id + 2",
+            "extra": "{}",
+            "filterable": True,
+            "groupby": True,
+            "id": 1,
+            "is_active": True,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": None,
+            "uuid": "5b0dc14a-8c1a-4fcb-8791-3a955d8609d3",
+            "verbose_name": None,
+        },
+        {
+            "advanced_data_type": None,
+            "column_name": "other_calc_column",
+            "description": None,
+            "expression": "id * 5",
+            "extra": "{}",
+            "filterable": True,
+            "groupby": True,
+            "id": 2,
+            "is_active": True,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": None,
+            "uuid": "5b0dc14a-8c1a-4fcb-8791-3a955d8609d3",
+            "verbose_name": "My verbose name",
+        },
+        {
+            "advanced_data_type": None,
+            "column_name": "id",
+            "description": "Primary key",
+            "expression": None,
+            "extra": "{}",
+            "filterable": True,
+            "groupby": False,
+            "id": 3,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": "INTEGER",
+            "uuid": "a2952680-2671-4a97-b608-3483cf7f11d2",
+            "verbose_name": "id",
+        },
+    ]
+
+
+def test_compute_columns_metadata_with_calc_columns_preserve_metadata() -> None:
+    """
+    Test the ``compute_columns_metadata`` helper with calculated columns
+    set in dbt and sync set to preserve metadata.
+    """
+    dbt_calc_columns = [
+        {
+            "column_name": "calc_column",
+            "expression": "id + 2",
+            "verbose_name": None,
+        },
+    ]
+    dataset_columns = [
+        {
+            "advanced_data_type": None,
+            "changed_on": "2024-01-23T20:29:33.945074",
+            "column_name": "calc_column",
+            "created_on": "2024-01-23T20:29:33.945070",
+            "description": None,
+            "expression": "id + 1",
+            "extra": "{}",
+            "filterable": True,
+            "groupby": True,
+            "id": 1,
+            "is_active": True,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": None,
+            "type_generic": None,
+            "uuid": "5b0dc14a-8c1a-4fcb-8791-3a955d8609d3",
+            "verbose_name": "My verbose name",
+        },
+        {
+            "advanced_data_type": None,
+            "changed_on": "2024-01-03T13:30:19.139128",
+            "column_name": "id",
+            "created_on": "2021-12-22T16:59:38.825689",
+            "description": "Description for ID",
+            "expression": None,
+            "extra": "{}",
+            "filterable": True,
+            "groupby": False,
+            "id": 2,
+            "is_active": None,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": "INTEGER",
+            "type_generic": None,
+            "uuid": "a2952680-2671-4a97-b608-3483cf7f11d2",
+            "verbose_name": None,
+        },
+    ]
+
+    result = compute_columns_metadata(
+        [],
+        dataset_columns,
+        False,
+        False,
+        {},
+        dbt_calc_columns,
+    )
+    assert result == [
+        {
+            "advanced_data_type": None,
+            "column_name": "calc_column",
+            "description": None,
+            "expression": "id + 1",
+            "extra": "{}",
+            "filterable": True,
+            "groupby": True,
+            "id": 1,
+            "is_active": True,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": None,
+            "uuid": "5b0dc14a-8c1a-4fcb-8791-3a955d8609d3",
+            "verbose_name": "My verbose name",
+        },
+        {
+            "advanced_data_type": None,
+            "column_name": "id",
+            "description": "Description for ID",
+            "expression": None,
+            "extra": "{}",
+            "filterable": True,
+            "groupby": False,
+            "id": 2,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": "INTEGER",
+            "uuid": "a2952680-2671-4a97-b608-3483cf7f11d2",
+            "verbose_name": None,
+        },
+    ]
+
+
+def test_compute_columns_metadata_with_calc_columns_default_configs() -> None:
+    """
+    Test the ``compute_columns_metadata`` helper with calculated columns
+    set in dbt and sync set to merge metadata.
+    """
+    dbt_columns = [{"name": "id"}]
+    dbt_calc_columns = [
+        {
+            "column_name": "calc_column",
+            "expression": "id + 2",
+            "description": "dbt desc",
+        },
+    ]
+    default_column_config = {"description": "default dbt desc", "extra": None}
+    dataset_columns = [
+        {
+            "advanced_data_type": None,
+            "changed_on": "2024-01-23T20:29:33.945074",
+            "column_name": "calc_column",
+            "created_on": "2024-01-23T20:29:33.945070",
+            "description": None,
+            "expression": "id + 1",
+            "extra": "{}",
+            "filterable": True,
+            "groupby": True,
+            "id": 1,
+            "is_active": True,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": None,
+            "type_generic": None,
+            "uuid": "5b0dc14a-8c1a-4fcb-8791-3a955d8609d3",
+            "verbose_name": "My verbose name",
+        },
+        {
+            "advanced_data_type": None,
+            "changed_on": "2024-01-03T13:30:19.139128",
+            "column_name": "id",
+            "created_on": "2021-12-22T16:59:38.825689",
+            "description": "Description for ID",
+            "expression": None,
+            "extra": "{}",
+            "filterable": True,
+            "groupby": False,
+            "id": 2,
+            "is_active": None,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": "INTEGER",
+            "type_generic": None,
+            "uuid": "a2952680-2671-4a97-b608-3483cf7f11d2",
+            "verbose_name": None,
+        },
+    ]
+
+    result = compute_columns_metadata(
+        dbt_columns,
+        dataset_columns,
+        False,
+        True,
+        default_column_config,
+        dbt_calc_columns,
+    )
+    assert result == [
+        {
+            "advanced_data_type": None,
+            "column_name": "calc_column",
+            "description": "dbt desc",
+            "expression": "id + 2",
+            "extra": None,
+            "filterable": True,
+            "groupby": True,
+            "id": 1,
+            "is_active": True,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": None,
+            "uuid": "5b0dc14a-8c1a-4fcb-8791-3a955d8609d3",
+            "verbose_name": "My verbose name",
+        },
+        {
+            "advanced_data_type": None,
+            "column_name": "id",
+            "description": "default dbt desc",
+            "expression": None,
+            "extra": None,
+            "filterable": True,
+            "groupby": False,
+            "id": 2,
+            "is_dttm": False,
+            "python_date_format": None,
+            "type": "INTEGER",
+            "uuid": "a2952680-2671-4a97-b608-3483cf7f11d2",
+            "verbose_name": "id",
+        },
+    ]
 
 
 def test_compute_dataset_metadata_with_dbt_metadata() -> None:


### PR DESCRIPTION
This PR adds support for syncing calculated columns from the dbt model. These should be defined under `$model.meta.superset.calculated_columns` (list).

The behavior is:

**Default sync (`reload_columns` set to `True` and `merge_metadata` set to `False`)**

In this configuration, metrics from dbt are synced to Superset, and metrics that were only present in the dataset (and not in the model) are deleted. This is the same behavior for calculated columns:
* If there isn't any calculated columns defined in dbt, then existing calculated columns from the dataset are preserved. This is to avoid breaking changes (as currently calculated columns aren't deleted in this flow).
* If there's any calculated column defined in dbt, then these are synced and Superset-only calculated columns are removed. 

**Merge metadata (`merge_metadata` set to `True` and `reload_columns` set to `False`)**
* Superset-only calculated columns are preserved.
* Metadata defined in dbt is synced.

**Preserve Metadata (both `merge_metadata` and `reload_columns` set to `False`)**
* Superset is the source of truth.
* new dbt calculated columns are synced.