### PR TITLE
chore: Write to log file after every step

### DIFF
--- a/src/preset_cli/cli/superset/import_.py
+++ b/src/preset_cli/cli/superset/import_.py
@@ -86,8 +86,8 @@ def import_ownership(
     client = SupersetClient(baseurl=URL(ctx.obj["INSTANCE"]), auth=ctx.obj["AUTH"])
 
     log_file_path, logs = get_logs(LogType.OWNERSHIP)
-    assets_to_skip = {log["uuid"] for log in logs[LogType.OWNERSHIP.value]} | {
-        log["uuid"] for log in logs[LogType.ASSETS.value] if log["status"] == "FAILED"
+    assets_to_skip = {log["uuid"] for log in logs[LogType.OWNERSHIP]} | {
+        log["uuid"] for log in logs[LogType.ASSETS] if log["status"] == "FAILED"
     }
 
     with open(path, encoding="utf-8") as input_:
@@ -112,10 +112,10 @@ def import_ownership(
                             raise
                         asset_log["status"] = "FAILED"
 
-                    logs[LogType.OWNERSHIP.value].append(asset_log)
+                    logs[LogType.OWNERSHIP].append(asset_log)
                     write_logs_to_file(log_file, logs)
 
     if not continue_on_error or not any(
-        log["status"] == "FAILED" for log in logs[LogType.OWNERSHIP.value]
+        log["status"] == "FAILED" for log in logs[LogType.OWNERSHIP]
     ):
         clean_logs(LogType.OWNERSHIP, logs)

--- a/src/preset_cli/cli/superset/import_.py
+++ b/src/preset_cli/cli/superset/import_.py
@@ -2,17 +2,21 @@
 Commands to import RLS rules, ownership, and more.
 """
 
+import logging
+
 import click
 import yaml
 from yarl import URL
 
 from preset_cli.api.clients.superset import SupersetClient
 from preset_cli.cli.superset.lib import (
-    add_asset_to_log_dict,
+    LogType,
     clean_logs,
     get_logs,
     write_logs_to_file,
 )
+
+_logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -79,57 +83,39 @@ def import_ownership(
     """
     Import resource ownership from a YAML file.
     """
-    auth = ctx.obj["AUTH"]
-    url = URL(ctx.obj["INSTANCE"])
-    client = SupersetClient(url, auth)
+    client = SupersetClient(baseurl=URL(ctx.obj["INSTANCE"]), auth=ctx.obj["AUTH"])
 
-    logs = get_logs()
-    failed_assets = (
-        {log["uuid"] for log in logs["assets"] if log["status"] == "FAILED"}
-        if logs.get("assets")
-        else set()
-    )
-
-    # Remove FAILED logs to re-try them
-    if "ownership" in logs:
-        logs["ownership"] = [
-            asset for asset in logs["ownership"] if asset["status"] != "FAILED"
-        ]
-    else:
-        logs["ownership"] = []
-
-    assets_to_skip = {log["uuid"] for log in logs["ownership"]} | failed_assets
+    log_file_path, logs = get_logs(LogType.OWNERSHIP)
+    assets_to_skip = {log["uuid"] for log in logs[LogType.OWNERSHIP.value]} | {
+        log["uuid"] for log in logs[LogType.ASSETS.value] if log["status"] == "FAILED"
+    }
 
     with open(path, encoding="utf-8") as input_:
         config = yaml.load(input_, Loader=yaml.SafeLoader)
+
+    with open(log_file_path, "w", encoding="utf-8") as log_file:
         for resource_name, resources in config.items():
             for ownership in resources:
                 if ownership["uuid"] not in assets_to_skip:
+
+                    _logger.info(
+                        "Importing ownership for %s %s",
+                        resource_name,
+                        ownership["name"],
+                    )
+                    asset_log = {"uuid": ownership["uuid"], "status": "SUCCESS"}
+
                     try:
                         client.import_ownership(resource_name, ownership)
                     except Exception:  # pylint: disable=broad-except
                         if not continue_on_error:
-                            write_logs_to_file(logs)
                             raise
+                        asset_log["status"] = "FAILED"
 
-                        add_asset_to_log_dict(
-                            "ownership",
-                            logs,
-                            "FAILED",
-                            ownership["uuid"],
-                        )
-                        continue
-
-                    add_asset_to_log_dict(
-                        "ownership",
-                        logs,
-                        "SUCCESS",
-                        ownership["uuid"],
-                    )
+                    logs[LogType.OWNERSHIP.value].append(asset_log)
+                    write_logs_to_file(log_file, logs)
 
     if not continue_on_error or not any(
-        log["status"] == "FAILED" for log in logs["ownership"]
+        log["status"] == "FAILED" for log in logs[LogType.OWNERSHIP.value]
     ):
-        clean_logs("ownership", logs)
-    else:
-        write_logs_to_file(logs)
+        clean_logs(LogType.OWNERSHIP, logs)

--- a/src/preset_cli/cli/superset/lib.py
+++ b/src/preset_cli/cli/superset/lib.py
@@ -24,14 +24,14 @@ class LogType(str, Enum):
     OWNERSHIP = "ownership"
 
 
-def get_logs(log_type: LogType) -> Tuple[Path, Dict[str, Any]]:
+def get_logs(log_type: LogType) -> Tuple[Path, Dict[LogType, Any]]:
     """
     Returns the path and content of the progress log file.
 
     Creates the file if it does not exist yet. Filters out FAILED
     entries for the particular log type. Defaults to an empty list.
     """
-    base_logs: Dict[str, Any] = {log_type.value: [] for log_type in LogType}
+    base_logs: Dict[LogType, Any] = {log_type_: [] for log_type_ in LogType}
 
     if not LOG_FILE_PATH.exists():
         LOG_FILE_PATH.touch()
@@ -40,31 +40,41 @@ def get_logs(log_type: LogType) -> Tuple[Path, Dict[str, Any]]:
     with open(LOG_FILE_PATH, "r", encoding="utf-8") as log_file:
         logs = yaml.load(log_file, Loader=yaml.SafeLoader) or {}
 
+    logs = {LogType(log_type): log_entries for log_type, log_entries in logs.items()}
     dict_merge(base_logs, logs)
-    base_logs[log_type.value] = [
-        log for log in base_logs[log_type.value] if log["status"] != "FAILED"
+    base_logs[log_type] = [
+        log for log in base_logs[log_type] if log["status"] != "FAILED"
     ]
     return LOG_FILE_PATH, base_logs
 
 
-def write_logs_to_file(log_file: IO[str], logs: Dict[str, Any]) -> None:
+def serialize_enum_logs_to_string(logs: Dict[LogType, Any]) -> Dict[str, Any]:
+    """
+    Helper method to serialize the enum keys in the logs dict to str.
+    """
+    return {log_type.value: log_entries for log_type, log_entries in logs.items()}
+
+
+def write_logs_to_file(log_file: IO[str], logs: Dict[LogType, Any]) -> None:
     """
     Writes logs list to .log file.
     """
+    logs_ = serialize_enum_logs_to_string(logs)
     log_file.seek(0)
-    yaml.dump(logs, log_file)
+    yaml.dump(logs_, log_file)
     log_file.truncate()
 
 
-def clean_logs(log_type: LogType, logs: Dict[str, Any]) -> None:
+def clean_logs(log_type: LogType, logs: Dict[LogType, Any]) -> None:
     """
     Cleans the progress log file for the specific log type.
 
     If there are no other log types, the file is deleted.
     """
-    logs.pop(log_type.value, None)
+    logs.pop(log_type, None)
     if any(logs.values()):
         with open(LOG_FILE_PATH, "w", encoding="utf-8") as log_file:
-            yaml.dump(logs, log_file)
+            logs_ = serialize_enum_logs_to_string(logs)
+            yaml.dump(logs_, log_file)
     else:
         LOG_FILE_PATH.unlink()

--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -349,7 +349,7 @@ def import_resources_individually(  # pylint: disable=too-many-locals
     related_configs: Dict[str, Dict[Path, AssetConfig]] = {}
 
     log_file_path, logs = get_logs(LogType.ASSETS)
-    assets_to_skip = {Path(log["path"]) for log in logs[LogType.ASSETS.value]}
+    assets_to_skip = {Path(log["path"]) for log in logs[LogType.ASSETS]}
 
     with open(log_file_path, "w", encoding="utf-8") as log_file:
         for resource_name, get_related_uuids in imports:
@@ -376,12 +376,12 @@ def import_resources_individually(  # pylint: disable=too-many-locals
                     asset_log["status"] = "FAILED"
 
                 related_configs[config["uuid"]] = asset_configs
-                logs[LogType.ASSETS.value].append(asset_log)
+                logs[LogType.ASSETS].append(asset_log)
                 assets_to_skip.add(path)
                 write_logs_to_file(log_file, logs)
 
     if not continue_on_error or not any(
-        log["status"] == "FAILED" for log in logs[LogType.ASSETS.value]
+        log["status"] == "FAILED" for log in logs[LogType.ASSETS]
     ):
         clean_logs(LogType.ASSETS, logs)
 

--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -29,7 +29,7 @@ from yarl import URL
 
 from preset_cli.api.clients.superset import SupersetClient
 from preset_cli.cli.superset.lib import (
-    add_asset_to_log_dict,
+    LogType,
     clean_logs,
     get_logs,
     write_logs_to_file,
@@ -348,63 +348,42 @@ def import_resources_individually(  # pylint: disable=too-many-locals
     asset_configs: Dict[Path, AssetConfig]
     related_configs: Dict[str, Dict[Path, AssetConfig]] = {}
 
-    logs = get_logs()
+    log_file_path, logs = get_logs(LogType.ASSETS)
+    assets_to_skip = {Path(log["path"]) for log in logs[LogType.ASSETS.value]}
 
-    # Remove FAILED logs to re-try them
-    if "assets" in logs:
-        logs["assets"] = [
-            asset for asset in logs["assets"] if asset["status"] != "FAILED"
-        ]
-    else:
-        logs["assets"] = []
+    with open(log_file_path, "w", encoding="utf-8") as log_file:
+        for resource_name, get_related_uuids in imports:
+            for path, config in configs.items():
+                if path.parts[1] != resource_name or path in assets_to_skip:
+                    continue
 
-    assets_to_skip = {Path(log["path"]) for log in logs["assets"]}
+                asset_configs = {path: config}
+                _logger.info("Importing %s", path.relative_to("bundle"))
+                asset_log = {
+                    "uuid": config["uuid"],
+                    "path": str(path),
+                    "status": "SUCCESS",
+                }
 
-    for resource_name, get_related_uuids in imports:
-        for path, config in configs.items():
-            if path.parts[1] != resource_name or path in assets_to_skip:
-                continue
+                try:
+                    for uuid in get_related_uuids(config):
+                        asset_configs.update(related_configs[uuid])
+                    contents = {str(k): yaml.dump(v) for k, v in asset_configs.items()}
+                    import_resources(contents, client, overwrite)
+                except Exception:  # pylint: disable=broad-except
+                    if not continue_on_error:
+                        raise
+                    asset_log["status"] = "FAILED"
 
-            asset_configs = {path: config}
-            _logger.info("Importing %s", path.relative_to("bundle"))
-
-            try:
-                for uuid in get_related_uuids(config):
-                    asset_configs.update(related_configs[uuid])
-                contents = {str(k): yaml.dump(v) for k, v in asset_configs.items()}
-                import_resources(contents, client, overwrite)
-            except Exception:  # pylint: disable=broad-except
-                if not continue_on_error:
-                    write_logs_to_file(logs)
-                    raise
-
-                add_asset_to_log_dict(
-                    "assets",
-                    logs,
-                    "FAILED",
-                    config["uuid"],
-                    asset_path=path,
-                    set_=assets_to_skip,
-                )
-                continue
-
-            add_asset_to_log_dict(
-                "assets",
-                logs,
-                "SUCCESS",
-                config["uuid"],
-                asset_path=path,
-                set_=assets_to_skip,
-            )
-
-            related_configs[config["uuid"]] = asset_configs
+                related_configs[config["uuid"]] = asset_configs
+                logs[LogType.ASSETS.value].append(asset_log)
+                assets_to_skip.add(path)
+                write_logs_to_file(log_file, logs)
 
     if not continue_on_error or not any(
-        log["status"] == "FAILED" for log in logs["assets"]
+        log["status"] == "FAILED" for log in logs[LogType.ASSETS.value]
     ):
-        clean_logs("assets", logs)
-    else:
-        write_logs_to_file(logs)
+        clean_logs(LogType.ASSETS, logs)
 
 
 def get_dashboard_related_uuids(config: AssetConfig) -> Iterator[str]:

--- a/tests/cli/superset/import_test.py
+++ b/tests/cli/superset/import_test.py
@@ -233,6 +233,7 @@ def test_import_ownership_failure(mocker: MockerFixture, fs: FakeFilesystem) -> 
         content = yaml.load(log, Loader=yaml.SafeLoader)
 
     assert content == {
+        "assets": [],
         "ownership": [
             {
                 "uuid": "uuid1",
@@ -289,6 +290,7 @@ def test_import_ownership_failure_continue(
         content = yaml.load(log, Loader=yaml.SafeLoader)
 
     assert content == {
+        "assets": [],
         "ownership": [
             {
                 "uuid": "uuid1",
@@ -302,7 +304,7 @@ def test_import_ownership_failure_continue(
     }
 
 
-def test_import_ownership_continue_no_errors(
+def test_import_ownership_continue_on_errors(
     mocker: MockerFixture,
     fs: FakeFilesystem,
 ) -> None:

--- a/tests/cli/superset/lib_test.py
+++ b/tests/cli/superset/lib_test.py
@@ -10,7 +10,7 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest_mock import MockerFixture
 
 from preset_cli.cli.superset.lib import (
-    add_asset_to_log_dict,
+    LogType,
     clean_logs,
     get_logs,
     write_logs_to_file,
@@ -22,7 +22,10 @@ def test_get_logs_new_file(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     Test the ``get_logs`` helper when the log file does not exist.
     """
     mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", Path("progress.log"))
-    assert get_logs() == {}
+    assert get_logs(LogType.ASSETS) == (
+        Path("progress.log"),
+        {"assets": [], "ownership": []},
+    )
 
 
 def test_get_logs_existing_file(mocker: MockerFixture, fs: FakeFilesystem) -> None:
@@ -39,6 +42,11 @@ def test_get_logs_existing_file(mocker: MockerFixture, fs: FakeFilesystem) -> No
                 "status": "SUCCESS",
                 "uuid": "uuid1",
             },
+            {
+                "path": "/path/to/root/first_path",
+                "status": "FAILED",
+                "uuid": "uuid3",
+            },
         ],
         "ownership": [
             {
@@ -53,106 +61,26 @@ def test_get_logs_existing_file(mocker: MockerFixture, fs: FakeFilesystem) -> No
     )
     mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", root / "progress.log")
 
-    assert get_logs() == logs_content
-
-
-def test_add_asset_to_log_dict_asset_import() -> None:
-    """
-    Test the ``add_asset_to_log_dict`` helper when passing asset logs.
-    """
-    logs = {
-        "assets": [
-            {
-                "path": "/path/to/root/first_path",
-                "status": "SUCCESS",
-                "uuid": "uuid1",
-            },
-        ],
-    }
-    skip = {Path("/path/to/root/first_path")}
-    add_asset_to_log_dict(
-        "assets",
-        logs,
-        "FAILED",
-        "uuid2",
-        asset_path=Path("/path/to/root/second_path"),
-        set_=skip,
+    assert get_logs(LogType.ASSETS) == (
+        root / "progress.log",
+        {
+            "assets": [
+                {
+                    "path": "/path/to/root/first_path",
+                    "status": "SUCCESS",
+                    "uuid": "uuid1",
+                },
+            ],
+            "ownership": [
+                {
+                    "status": "SUCCESS",
+                    "uuid": "uuid2",
+                },
+            ],
+        },
     )
 
-    assert logs == {
-        "assets": [
-            {
-                "path": "/path/to/root/first_path",
-                "status": "SUCCESS",
-                "uuid": "uuid1",
-            },
-            {
-                "path": "/path/to/root/second_path",
-                "status": "FAILED",
-                "uuid": "uuid2",
-            },
-        ],
-    }
-    assert skip == {Path("/path/to/root/first_path"), Path("/path/to/root/second_path")}
-
-    logs = {"assets": []}
-    skip = set()
-    add_asset_to_log_dict(
-        "assets",
-        logs,
-        "SUCCESS",
-        "uuid3",
-        asset_path=Path("/path/to/root/third_path"),
-        set_=skip,
-    )
-
-    assert logs == {
-        "assets": [
-            {
-                "path": "/path/to/root/third_path",
-                "status": "SUCCESS",
-                "uuid": "uuid3",
-            },
-        ],
-    }
-    assert skip == {Path("/path/to/root/third_path")}
-
-
-def test_add_asset_to_log_dict_ownership_import() -> None:
-    """
-    Test the ``add_asset_to_log_dict`` helper when passing ownership logs.
-    """
-    logs = {
-        "assets": [
-            {
-                "path": "/path/to/root/first_path",
-                "status": "SUCCESS",
-                "uuid": "uuid1",
-            },
-        ],
-    }
-    add_asset_to_log_dict(
-        "ownership",
-        logs,
-        "FAILED",
-        "uuid2",
-    )
-
-    assert logs == {
-        "assets": [
-            {
-                "path": "/path/to/root/first_path",
-                "status": "SUCCESS",
-                "uuid": "uuid1",
-            },
-        ],
-        "ownership": [
-            {
-                "status": "FAILED",
-                "uuid": "uuid2",
-            },
-        ],
-    }
+    assert get_logs(LogType.OWNERSHIP) == (root / "progress.log", logs_content)
 
 
 def test_write_logs_to_file(mocker: MockerFixture, fs: FakeFilesystem) -> None:
@@ -198,7 +126,8 @@ def test_write_logs_to_file(mocker: MockerFixture, fs: FakeFilesystem) -> None:
         ],
     }
 
-    write_logs_to_file(new_logs)
+    with open(root / "progress.log", "r+", encoding="utf-8") as file:
+        write_logs_to_file(file, new_logs)
 
     with open(root / "progress.log", encoding="utf-8") as file:
         content = yaml.load(file, Loader=yaml.SafeLoader)
@@ -229,7 +158,7 @@ def test_clean_logs_delete_file(mocker: MockerFixture, fs: FakeFilesystem) -> No
     )
     assert logs_path.exists()
 
-    clean_logs("assets", logs)
+    clean_logs(LogType.ASSETS, logs)
     assert not logs_path.exists()
 
 
@@ -262,7 +191,7 @@ def test_clean_logs_keep_file(mocker: MockerFixture, fs: FakeFilesystem) -> None
     )
     assert logs_path.exists()
 
-    clean_logs("assets", logs)
+    clean_logs(LogType.ASSETS, logs)
 
     with open(logs_path, encoding="utf-8") as log:
         content = yaml.load(log, Loader=yaml.SafeLoader)

--- a/tests/cli/superset/sync/native/command_test.py
+++ b/tests/cli/superset/sync/native/command_test.py
@@ -1361,6 +1361,7 @@ def test_import_resources_individually_checkpoint(
                 "status": "SUCCESS",
             },
         ],
+        "ownership": [],
     }
 
     # retry
@@ -1440,6 +1441,7 @@ def test_import_resources_individually_continue(
                 "status": "SUCCESS",
             },
         ],
+        "ownership": [],
     }
 
     # retry should succeed and delete the log file


### PR DESCRIPTION
This PR implements the remaining feedback from https://github.com/preset-io/backend-sdk/pull/331 + enforces the progress is written to the log file continuously (as opposed to just at the end) so that if the command is aborted/cancelled progress is stored.