### PR TITLE
feat(import assets): Pass DB passwords in the import command

### DIFF
--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -278,11 +278,7 @@ def native(  # pylint: disable=too-many-locals, too-many-arguments, too-many-bra
     if load_env:
         env["env"] = os.environ  # type: ignore
 
-    pwds = (
-        {kv.partition("=")[0]: kv.partition("=")[2] for kv in db_password}
-        if db_password
-        else {}
-    )
+    pwds = dict(kv.split("=", 1) for kv in db_password or [])
 
     # read all the YAML files
     configs: Dict[Path, AssetConfig] = {}

--- a/tests/cli/superset/sync/native/command_test.py
+++ b/tests/cli/superset/sync/native/command_test.py
@@ -2017,7 +2017,6 @@ def test_native_invalid_asset_type(mocker: MockerFixture, fs: FakeFilesystem) ->
 
 
 def test_native_with_db_passwords(mocker: MockerFixture, fs: FakeFilesystem) -> None:
-    # pylint: disable=line-too-long
     """
     Test the ``native`` command while passing db passwords in the command.
     """


### PR DESCRIPTION
Currently when importing a new DB connection the CLI prompts the user to enter its password. This PR adds the ability to specify the DB password as an argument to the CLI command, to skip the prompt (better for automations/integrations).