### PR TITLE
chore: Add debug logging for import resources individually

### DIFF
--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -374,6 +374,7 @@ def import_resources_individually(  # pylint: disable=too-many-locals
                     continue
 
                 asset_configs = {path: config}
+                _logger.debug("Processing %s for import", path.relative_to("bundle"))
                 for uuid in get_related_uuids(config):
                     asset_configs.update(related_configs[uuid])
                 related_configs[config["uuid"]] = asset_configs


### PR DESCRIPTION
Currently we're logging when importing a file, but we still iterate through other files (dependencies) that don't get imported, and an issue could occur during this step. This additional `debug` statement helps troubleshooting this issue.