### PR TITLE
chore(sync native): Continue the import in case an error happens while getting dependencies

### DIFF
--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -375,24 +375,24 @@ def import_resources_individually(  # pylint: disable=too-many-locals
 
                 asset_configs = {path: config}
                 _logger.debug("Processing %s for import", path.relative_to("bundle"))
-                for uuid in get_related_uuids(config):
-                    asset_configs.update(related_configs[uuid])
-                related_configs[config["uuid"]] = asset_configs
-
-                if path in assets_to_skip or (
-                    asset_type != ResourceType.ASSET
-                    and asset_type.resource_name not in resource_name
-                ):
-                    continue
-
-                _logger.info("Importing %s", path.relative_to("bundle"))
                 asset_log = {
                     "uuid": config["uuid"],
                     "path": str(path),
                     "status": "SUCCESS",
                 }
-
                 try:
+                    for uuid in get_related_uuids(config):
+                        asset_configs.update(related_configs[uuid])
+                    related_configs[config["uuid"]] = asset_configs
+
+                    if path in assets_to_skip or (
+                        asset_type != ResourceType.ASSET
+                        and asset_type.resource_name not in resource_name
+                    ):
+                        continue
+
+                    _logger.info("Importing %s", path.relative_to("bundle"))
+
                     contents = {str(k): yaml.dump(v) for k, v in asset_configs.items()}
                     import_resources(contents, client, overwrite, asset_type)
                 except Exception:  # pylint: disable=broad-except

--- a/tests/cli/superset/sync/native/command_test.py
+++ b/tests/cli/superset/sync/native/command_test.py
@@ -1160,6 +1160,27 @@ def test_native_split_continue(  # pylint: disable=too-many-locals
         },
         "uuid": "5",
     }
+    dashboard_deleted_chart = {
+        "dashboard_title": "Dashboard with deleted chart",
+        "is_managed_externally": False,
+        "position": {
+            "DASHBOARD_VERSION_KEY": "v2",
+            "CHART-BVI44PWH": {
+                "type": "CHART",
+                "meta": {
+                    "uuid": "3",
+                },
+            },
+            "CHART-BLAH": {
+                "type": "CHART",
+                "meta": {
+                    "uuid": None,
+                },
+            },
+        },
+        "metadata": {},
+        "uuid": "6",
+    }
 
     fs.create_file(
         root / "databases/gsheets.yaml",
@@ -1181,6 +1202,10 @@ def test_native_split_continue(  # pylint: disable=too-many-locals
         root / "dashboards/dashboard_deleted_dataset.yaml",
         contents=yaml.dump(dashboard_deleted_dataset),
     )
+    fs.create_file(
+        root / "dashboards/dashboard_deleted_chart.yaml",
+        contents=yaml.dump(dashboard_deleted_chart),
+    )
 
     SupersetClient = mocker.patch(
         "preset_cli.cli.superset.sync.native.command.SupersetClient",
@@ -1191,6 +1216,8 @@ def test_native_split_continue(  # pylint: disable=too-many-locals
     )
     mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
     mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", Path("progress.log"))
+
+    assert not Path("progress.log").exists()
 
     runner = CliRunner()
     result = runner.invoke(
@@ -1259,6 +1286,43 @@ def test_native_split_continue(  # pylint: disable=too-many-locals
         ],
         any_order=True,
     )
+
+    with open("progress.log", encoding="utf-8") as log:
+        content = yaml.load(log, Loader=yaml.SafeLoader)
+
+    assert content["ownership"] == []
+    assert content["assets"] == [
+        {
+            "path": "bundle/databases/gsheets.yaml",
+            "uuid": "1",
+            "status": "SUCCESS",
+        },
+        {
+            "path": "bundle/datasets/gsheets/test.yaml",
+            "uuid": "2",
+            "status": "SUCCESS",
+        },
+        {
+            "path": "bundle/charts/chart.yaml",
+            "uuid": "3",
+            "status": "SUCCESS",
+        },
+        {
+            "path": "bundle/dashboards/dashboard_deleted_chart.yaml",
+            "uuid": "6",
+            "status": "FAILED",
+        },
+        {
+            "path": "bundle/dashboards/dashboard_deleted_dataset.yaml",
+            "uuid": "5",
+            "status": "SUCCESS",
+        },
+        {
+            "path": "bundle/dashboards/dashboard.yaml",
+            "uuid": "4",
+            "status": "SUCCESS",
+        },
+    ]
 
 
 def test_native_continue_without_split(


### PR DESCRIPTION
When running an import with the `--split` and `--continue-on-error` flags, the CLI imports each asset individually, dynamically identifying all dependencies to build a ZIP file to use.

We were currently handling any import failures (by adding it to the `progress.log` file and moving to the next item) but it's also possible that some issues happen while getting all dependencies from an asset. For example, if you delete a chart that's used in a dashboard and reflect this change in the `position`, the dashboard would have a `chart` element with `uuid: None`. 

This PR moves the logic to get all dependencies inside the `try/except` block, so that these failures don't interrupt the import (and are also added to the `progress.log` file).
