### PR TITLE
fix(Preset): Export users

### DIFF
--- a/tests/api/clients/preset_test.py
+++ b/tests/api/clients/preset_test.py
@@ -159,7 +159,7 @@ def test_preset_client_export_users(requests_mock: Mocker) -> None:
     )
 
     auth = Auth()
-    client = PresetClient("https://api.app.preset.io/", auth)
+    client = PresetClient("https://ws.preset.io/", auth)
     assert list(client.export_users(URL("https://superset.example.org/"))) == [
         {
             "id": 1,

--- a/tests/api/clients/preset_test.py
+++ b/tests/api/clients/preset_test.py
@@ -136,17 +136,30 @@ def test_preset_client_export_users(requests_mock: Mocker) -> None:
     )
 
     requests_mock.get(
-        "https://superset.example.org/roles/add",
-        text="""
-<select id="user">
-    <option value="1">Alice Doe</option>
-    <option value="2">Bob Doe</option>
-</select>
-    """,
+        "https://superset.example.org/api/v1/chart/related/owners?q=(page:0,page_size:100)",
+        json={
+            "count": 2,
+            "result": [
+                {
+                    "extra": {"active": True, "email": "adoe@example.com"},
+                    "text": "Alice Doe",
+                    "value": 1,
+                },
+                {
+                    "extra": {"active": True, "email": "bdoe@example.com"},
+                    "text": "Bob Doe",
+                    "value": 2,
+                },
+            ],
+        },
+    )
+    requests_mock.get(
+        "https://superset.example.org/api/v1/chart/related/owners?q=(page:1,page_size:100)",
+        json={"count": 2, "result": []},
     )
 
     auth = Auth()
-    client = PresetClient("https://ws.preset.io/", auth)
+    client = PresetClient("https://api.app.preset.io/", auth)
     assert list(client.export_users(URL("https://superset.example.org/"))) == [
         {
             "id": 1,

--- a/tests/api/clients/superset_test.py
+++ b/tests/api/clients/superset_test.py
@@ -1927,14 +1927,40 @@ def test_export_users_preset(requests_mock: Mocker) -> None:
     )
 
     requests_mock.get(
-        "https://superset.example.org/roles/add",
-        text="""
-<select id="user">
-    <option value="1">Alice Doe</option>
-    <option value="2">Bob Doe</option>
-    <option value="3">Clarisse Doe</option>
-</select>
-    """,
+        "https://superset.example.org/api/v1/chart/related/owners?q=(page:0,page_size:100)",
+        json={
+            "count": 3,
+            "result": [
+                {
+                    "extra": {
+                        "active": True,
+                        "email": "adoe@example.com",
+                    },
+                    "text": "Alice Doe",
+                    "value": 1,
+                },
+                {
+                    "extra": {
+                        "active": True,
+                        "email": "bdoe@example.com",
+                    },
+                    "text": "Bob Doe",
+                    "value": 2,
+                },
+                {
+                    "extra": {
+                        "active": True,
+                        "email": "cdoe@example.com",
+                    },
+                    "text": "Clarisse Doe",
+                    "value": 3,
+                },
+            ],
+        },
+    )
+    requests_mock.get(
+        "https://superset.example.org/api/v1/chart/related/owners?q=(page:1,page_size:100)",
+        json={"count": 3, "result": []},  # empty result to break the loop
     )
 
     auth = Auth()


### PR DESCRIPTION
In Preset, the Superset Users List view is disabled (since users are managed through Preset Manager). That said, in order to export users (with their local Superset IDs) we would parse the DOM of the Add DAR view. 

There was a change to this view so that the users are not loaded to the DOM anymore -- instead, there's a user search field. 

This PR updates the logic specifically for Preset Cloud to get the user information from the `/api/v1/chart/related/owners` field (which lists all members with proper pagination).

This is a temporary fix, as there's ongoing work to migrate the Superset Roles view to RESTful, and later do the same with Preset's DAR view.