### PR TITLE
fix(import ownership): Support emails with uppercase characters

### DIFF
--- a/src/preset_cli/api/clients/preset.py
+++ b/src/preset_cli/api/clients/preset.py
@@ -160,7 +160,7 @@ class PresetClient:  # pylint: disable=too-few-public-methods
                     "role": [],  # TODO (betodealmeida)
                     "first_name": payload["user"]["first_name"],
                     "last_name": payload["user"]["last_name"],
-                    "email": payload["user"]["email"],
+                    "email": payload["user"]["email"].lower(),
                 }
                 for payload in payload["payload"]
             ]
@@ -190,7 +190,10 @@ class PresetClient:  # pylint: disable=too-few-public-methods
                 break
 
             ids.update(
-                {user["extra"]["email"]: user["value"] for user in payload["result"]},
+                {
+                    user["extra"]["email"].lower(): user["value"]
+                    for user in payload["result"]
+                },
             )
 
             page += 1

--- a/src/preset_cli/api/clients/preset.py
+++ b/src/preset_cli/api/clients/preset.py
@@ -153,6 +153,7 @@ class PresetClient:  # pylint: disable=too-few-public-methods
             validate_response(response)
             payload = response.json()
 
+            # Teams with SAML SSO might have emails with uppercase characters
             team_members: List[UserType] = [
                 {
                     "id": 0,
@@ -189,6 +190,7 @@ class PresetClient:  # pylint: disable=too-few-public-methods
             if not payload["result"]:
                 break
 
+            # Teams with SAML SSO might have emails with uppercase characters
             ids.update(
                 {
                     user["extra"]["email"].lower(): user["value"]

--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -1190,7 +1190,7 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
         """
         if ownership["uuid"] in resource_ids:
             resource_id = resource_ids[ownership["uuid"]]
-            owner_ids = [user_ids[email] for email in ownership["owners"]]
+            owner_ids = [user_ids[email.lower()] for email in ownership["owners"]]
             self.update_resource(resource_name, resource_id, owners=owner_ids)
         else:
             raise Exception(

--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -1188,9 +1188,14 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
         """
         Import ownership on resources.
         """
-        resource_id = resource_ids[ownership["uuid"]]
-        owner_ids = [user_ids[email.lower()] for email in ownership["owners"]]
-        self.update_resource(resource_name, resource_id, owners=owner_ids)
+        if ownership["uuid"] in resource_ids:
+            resource_id = resource_ids[ownership["uuid"]]
+            owner_ids = [user_ids[email.lower()] for email in ownership["owners"]]
+            self.update_resource(resource_name, resource_id, owners=owner_ids)
+        else:
+            raise Exception(
+                f"Resource {ownership['name']} not found in the target instance.",
+            )
 
     def update_role(self, role_id: int, **kwargs: Any) -> None:
         """

--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -1188,15 +1188,9 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
         """
         Import ownership on resources.
         """
-        if ownership["uuid"] in resource_ids:
-            resource_id = resource_ids[ownership["uuid"]]
-            owner_ids = [user_ids[email.lower()] for email in ownership["owners"]]
-            self.update_resource(resource_name, resource_id, owners=owner_ids)
-        else:
-            raise Exception(
-                f"Resource {ownership['name']} (UUID: {ownership['uuid']})"
-                " not found in the target instance",
-            )
+        resource_id = resource_ids[ownership["uuid"]]
+        owner_ids = [user_ids[email.lower()] for email in ownership["owners"]]
+        self.update_resource(resource_name, resource_id, owners=owner_ids)
 
     def update_role(self, role_id: int, **kwargs: Any) -> None:
         """

--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -1192,6 +1192,10 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
             owner_ids = [user_ids[email] for email in ownership["owners"]]
             self.update_resource(resource_name, resource_id, owners=owner_ids)
         else:
+            _logger.debug(
+                "UUID %s not found in resources list.",
+                ownership["uuid"],
+            )
             raise Exception(
                 f"Resource {ownership['name']} not found in the target instance.",
             )

--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -492,6 +492,7 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
         if query_args:
             url %= query_args
 
+        _logger.debug("PUT %s\n%s", url, json.dumps(kwargs, indent=4))
         response = self.session.put(url, json=kwargs)
         validate_response(response)
 
@@ -1192,12 +1193,9 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
             owner_ids = [user_ids[email] for email in ownership["owners"]]
             self.update_resource(resource_name, resource_id, owners=owner_ids)
         else:
-            _logger.debug(
-                "UUID %s not found in resources list.",
-                ownership["uuid"],
-            )
             raise Exception(
-                f"Resource {ownership['name']} not found in the target instance.",
+                f"Resource {ownership['name']} (UUID: {ownership['uuid']})"
+                " not found in the target instance",
             )
 
     def update_role(self, role_id: int, **kwargs: Any) -> None:

--- a/src/preset_cli/cli/superset/import_.py
+++ b/src/preset_cli/cli/superset/import_.py
@@ -123,7 +123,13 @@ def import_ownership(  # pylint: disable=too-many-locals
                             users,
                             resource_ids,
                         )
-                    except Exception:  # pylint: disable=broad-except
+                    except Exception as exc:  # pylint: disable=broad-except
+                        _logger.debug(
+                            "Failed to import ownership for %s %s: %s",
+                            resource_name,
+                            ownership["name"],
+                            str(exc),
+                        )
                         if not continue_on_error:
                             raise
                         asset_log["status"] = "FAILED"

--- a/src/preset_cli/cli/superset/import_.py
+++ b/src/preset_cli/cli/superset/import_.py
@@ -99,6 +99,13 @@ def import_ownership(  # pylint: disable=too-many-locals
             resource_ids = {
                 str(v): k for k, v in client.get_uuids(resource_name).items()
             }
+            _logger.debug(
+                "Found %s %s in the Workspace",
+                len(resource_ids),
+                resource_name,
+            )
+            with open("resource_ids.yaml", "w", encoding="utf-8") as file:
+                yaml.dump(resource_ids, file, default_flow_style=False, sort_keys=False)
             for ownership in resources:
                 if ownership["uuid"] not in assets_to_skip:
 

--- a/src/preset_cli/cli/superset/import_.py
+++ b/src/preset_cli/cli/superset/import_.py
@@ -93,7 +93,7 @@ def import_ownership(  # pylint: disable=too-many-locals
     with open(path, encoding="utf-8") as input_:
         config = yaml.load(input_, Loader=yaml.SafeLoader)
 
-    users = {user["email"]: user["id"] for user in client.export_users()}
+    users = {user["email"].lower(): user["id"] for user in client.export_users()}
     with open(log_file_path, "w", encoding="utf-8") as log_file:
         for resource_name, resources in config.items():
             resource_ids = {

--- a/src/preset_cli/cli/superset/import_.py
+++ b/src/preset_cli/cli/superset/import_.py
@@ -93,19 +93,12 @@ def import_ownership(  # pylint: disable=too-many-locals
     with open(path, encoding="utf-8") as input_:
         config = yaml.load(input_, Loader=yaml.SafeLoader)
 
-    users = {user["email"].lower(): user["id"] for user in client.export_users()}
+    users = {user["email"]: user["id"] for user in client.export_users()}
     with open(log_file_path, "w", encoding="utf-8") as log_file:
         for resource_name, resources in config.items():
             resource_ids = {
                 str(v): k for k, v in client.get_uuids(resource_name).items()
             }
-            _logger.debug(
-                "Found %s %s in the Workspace",
-                len(resource_ids),
-                resource_name,
-            )
-            with open("resource_ids.yaml", "w", encoding="utf-8") as file:
-                yaml.dump(resource_ids, file, default_flow_style=False, sort_keys=False)
             for ownership in resources:
                 if ownership["uuid"] not in assets_to_skip:
 

--- a/tests/api/clients/superset_test.py
+++ b/tests/api/clients/superset_test.py
@@ -3529,7 +3529,7 @@ def test_import_ownership(requests_mock: Mocker) -> None:
         "dataset",
         {
             "name": "another_table",
-            "owners": ["other_admin@example.com", "other_adoe@example.com"],
+            "owners": ["other_admin@example.com", "Other_Adoe@example.com"],
             "uuid": "1192072c-4bee-4535-b8ee-e9f5fc4eb6a2",
         },
         users,

--- a/tests/api/clients/superset_test.py
+++ b/tests/api/clients/superset_test.py
@@ -1897,7 +1897,7 @@ def test_export_users_preset(requests_mock: Mocker) -> None:
                         "username": "bdoe",
                         "first_name": "Bob",
                         "last_name": "Doe",
-                        "email": "bdoe@example.com",
+                        "email": "BDoe@example.com",
                     },
                 },
             ],
@@ -1950,7 +1950,7 @@ def test_export_users_preset(requests_mock: Mocker) -> None:
                 {
                     "extra": {
                         "active": True,
-                        "email": "cdoe@example.com",
+                        "email": "CDoe@example.com",
                     },
                     "text": "Clarisse Doe",
                     "value": 3,


### PR DESCRIPTION
The `import-ownership` command needs to get all users from the Workspace (or Superset instance) and compare them with the YAML. It's possible the Superset instance has emails with uppercase characters (or the Preset Workspace). This PR normalizes all emails to lowercase before doing any comparison.