### PR TITLE
fix: Do not use reload_columns twice during dataset update

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/datasets.py
+++ b/src/preset_cli/cli/superset/sync/dbt/datasets.py
@@ -448,11 +448,7 @@ def sync_datasets(  # pylint: disable=too-many-locals, too-many-arguments
                 calculated_columns,
             )
             try:
-                client.update_dataset(
-                    dataset["id"],
-                    override_columns=reload_columns,
-                    columns=dataset_columns,
-                )
+                client.update_dataset(dataset["id"], columns=dataset_columns)
             except SupersetError:
                 failed_datasets.append(model["unique_id"])
                 continue

--- a/tests/cli/superset/sync/dbt/datasets_test.py
+++ b/tests/cli/superset/sync/dbt/datasets_test.py
@@ -166,11 +166,7 @@ def test_sync_datasets_new(mocker: MockerFixture) -> None:
                 override_columns=True,
                 **compute_dataset_metadata_mock(),
             ),
-            mock.call(
-                1,
-                override_columns=True,
-                columns=compute_columns_metadata_mock(),
-            ),
+            mock.call(1, columns=compute_columns_metadata_mock()),
         ],
     )
 
@@ -250,11 +246,7 @@ def test_sync_datasets_second_update_fails(mocker: MockerFixture) -> None:
                 override_columns=True,
                 **compute_dataset_metadata_mock(),
             ),
-            mock.call(
-                1,
-                override_columns=True,
-                columns=compute_columns_metadata_mock(),
-            ),
+            mock.call(1, columns=compute_columns_metadata_mock()),
         ],
     )
     assert working == []
@@ -404,11 +396,7 @@ def test_sync_datasets_custom_certification(mocker: MockerFixture) -> None:
                 override_columns=True,
                 **compute_dataset_metadata_mock(),
             ),
-            mock.call(
-                1,
-                override_columns=True,
-                columns=compute_columns_metadata_mock(),
-            ),
+            mock.call(1, columns=compute_columns_metadata_mock()),
         ],
     )
 
@@ -560,11 +548,7 @@ def test_sync_datasets_external_url_disallow_edits(mocker: MockerFixture) -> Non
                 override_columns=True,
                 **compute_dataset_metadata_mock(),
             ),
-            mock.call(
-                1,
-                override_columns=True,
-                columns=compute_columns_metadata_mock(),
-            ),
+            mock.call(1, columns=compute_columns_metadata_mock()),
         ],
     )
 
@@ -642,11 +626,7 @@ def test_sync_datasets_preserve_metadata(mocker: MockerFixture) -> None:
                 override_columns=False,
                 **compute_dataset_metadata_mock(),
             ),
-            mock.call(
-                1,
-                override_columns=False,
-                columns=compute_columns_metadata_mock(),
-            ),
+            mock.call(1, columns=compute_columns_metadata_mock()),
         ],
     )
 
@@ -724,11 +704,7 @@ def test_sync_datasets_merge_metadata(mocker: MockerFixture) -> None:
                 override_columns=False,
                 **compute_dataset_metadata_mock(),
             ),
-            mock.call(
-                1,
-                override_columns=False,
-                columns=compute_columns_metadata_mock(),
-            ),
+            mock.call(1, columns=compute_columns_metadata_mock()),
         ],
     )
 


### PR DESCRIPTION
During the `sync_dataset()` process, we call `client.update_dataset()` twice (and we're currently including `override_columns=reload_columns` in both commands):

First to update the dataset metadata:
``` python
update = compute_dataset_metadata(
    model,
    certification,
    disallow_edits,
    final_dataset_metrics,
    base_url,
    final_dataset_columns,
)

client.update_dataset(
    dataset["id"], override_columns=reload_columns, **update
)
```

Then to update its columns:
``` python
dbt_columns = model.get("columns")
if dbt_columns or calculated_columns:
    current_dataset_columns = client.get_dataset(dataset["id"])["columns"]
    dataset_columns = compute_columns_metadata(
        dbt_columns,
        current_dataset_columns,
        reload_columns,
        merge_metadata,
        default_configs.get("columns", {}),
        calculated_columns,
    )
    client.update_dataset(
        dataset["id"],
        override_columns=reload_columns,
        columns=dataset_columns
    )
```

When this parameter is included in the `PUT /api/v1/dataset/{pk}` API endpoint, Superset would "reset" all dataset columns, which includes setting `filterable` and `groupby` to `True` (even if these are being set to `False` via the dbt metadata).

This PR changes the logic so that the second call (which does the actual column update) no longer includes this param (which already took place in the first call) so that these metadata from dbt reflect properly.