### PR TITLE
chore: Support getting meta.superset from config

### DIFF
--- a/src/preset_cli/cli/superset/sync/dbt/exposures.py
+++ b/src/preset_cli/cli/superset/sync/dbt/exposures.py
@@ -9,8 +9,8 @@ from typing import Any, Dict, List, NamedTuple, Optional
 
 import yaml
 
-from preset_cli.api.clients.dbt import ModelSchema
 from preset_cli.api.clients.superset import SupersetClient
+from preset_cli.cli.superset.sync.dbt.schemas import ModelSchema
 
 # XXX: DashboardResponseType and DatasetResponseType
 

--- a/src/preset_cli/cli/superset/sync/dbt/lib.py
+++ b/src/preset_cli/cli/superset/sync/dbt/lib.py
@@ -16,7 +16,7 @@ from sqlalchemy.engine import Engine, create_engine
 from sqlalchemy.engine.url import URL
 from sqlalchemy.exc import NoSuchModuleError
 
-from preset_cli.api.clients.dbt import MetricSchema, ModelSchema, OGMetricSchema
+from preset_cli.cli.superset.sync.dbt.schemas import ModelSchema, OGMetricSchema
 from preset_cli.exceptions import CLIError
 
 _logger = logging.getLogger(__name__)
@@ -523,16 +523,3 @@ def get_og_metric_from_config(
     metric_config["dialect"] = dialect
 
     return metric_schema.load(metric_config)
-
-
-def parse_metric_meta(metric: MetricSchema) -> Dict[str, Any]:
-    """
-    Parses the metric's meta information.
-    """
-    kwargs = metric.get("meta", {}).pop("superset", {})
-    metric_name_override = kwargs.pop("metric_name", None)
-    return {
-        "meta": metric.get("meta", {}),
-        "kwargs": kwargs,
-        "metric_name_override": metric_name_override,
-    }

--- a/src/preset_cli/cli/superset/sync/dbt/schemas.py
+++ b/src/preset_cli/cli/superset/sync/dbt/schemas.py
@@ -1,0 +1,303 @@
+"""
+Schemas and enums/TypeDicts used in the DBT sync process for Superset.
+"""
+
+from enum import Enum
+from typing import Any, Dict, Type
+
+from marshmallow import EXCLUDE, INCLUDE, Schema, fields, post_load, pre_load
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+
+def parse_meta_properties(
+    entity: Dict[str, Any],
+    preserve_dbt_meta: bool = True,
+) -> None:
+    """
+    Parses the meta properties from an entity.
+
+    This helper performs two tasks:
+    1. dbt is migrating from $entity.meta to $entity.config.meta, so it
+    ensures `$entity.meta` gets the proper value.
+    2. Pops `superset` properties from meta to a new `superset_meta` key.
+
+    Setting `preserve_meta` to `False` would remove the `meta` key (useful when
+    we don't care about dbt-specific meta properties).
+    """
+    entity["meta"] = entity.get("meta") or entity.get("config", {}).get("meta", {})
+    entity["superset_meta"] = entity["meta"].pop("superset", {})
+    if not preserve_dbt_meta:
+        del entity["meta"]
+
+
+class PostelSchema(Schema):
+    """
+    Be liberal in what you accept, and conservative in what you send.
+
+    A schema that allows unknown fields. This way if the API returns new fields that
+    the client is not expecting no errors will be thrown when validating the payload.
+    """
+
+    class Meta:
+        """
+        Ignore unknown and unnecessary fields.
+        """
+
+        unknown = INCLUDE
+
+
+def PostelEnumField(enum: Type[Enum], *args: Any, **kwargs: Any) -> fields.Field:
+    """
+    Lenient replacement for ``EnumField``.
+
+    This allows us to keep track of the enums expected in a field, while still
+    accepting any unexpected new values that are introduced.
+    """
+    if issubclass(enum, str):
+        return fields.String(*args, **kwargs)
+
+    if issubclass(enum, int):
+        return fields.Integer(*args, **kwargs)
+
+    return fields.Raw(*args, **kwargs)
+
+
+class AccountSchema(PostelSchema):
+    """
+    Schema for a dbt account.
+    """
+
+    id = fields.Integer()
+    name = fields.String()
+
+
+class ProjectSchema(PostelSchema):
+    """
+    Schema for a dbt project.
+    """
+
+    id = fields.Integer(allow_none=True)
+    name = fields.String()
+
+
+class JobSchema(PostelSchema):
+    """
+    Schema for a dbt job.
+    """
+
+    id = fields.Integer(allow_none=True)
+    name = fields.String()
+
+
+class ColumnSchema(PostelSchema):
+    """
+    Schema for a dbt model column.
+    """
+
+    class Meta:
+        """
+        Delete dbt-specific fields that won't be used by Superset.
+        """
+
+        unknown = EXCLUDE
+
+    name = fields.String()
+    verbose_name = fields.String(allow_none=True)
+    description = fields.String(allow_none=True)
+    superset_meta = fields.Raw(allow_none=True)
+
+    @pre_load
+    def parse_meta(  # pylint: disable=unused-argument
+        self,
+        data: Dict[str, Any],
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        Parse the meta properties and populates the verbose name.
+        """
+        data["verbose_name"] = data["name"]
+        parse_meta_properties(data, preserve_dbt_meta=False)
+        return data
+
+    @post_load
+    def process_superset_metadata(  # pylint: disable=unused-argument
+        self,
+        data: Dict[str, Any],
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        Automatically unpack Superset meta as top-level keys.
+        """
+        superset_meta = data.pop("superset_meta")
+        return {
+            **data,
+            **superset_meta,
+        }
+
+
+class ModelSchema(PostelSchema):
+    """
+    Schema for a model.
+    """
+
+    depends_on = fields.List(fields.String())
+    children = fields.List(fields.String())
+    database = fields.String()
+    schema = fields.String()
+    description = fields.String()
+    meta = fields.Raw()
+    superset_meta = fields.Raw()
+    name = fields.String()
+    alias = fields.String(allow_none=True)
+    unique_id = fields.String()
+    tags = fields.List(fields.String())
+    columns = fields.List(fields.Nested(ColumnSchema))
+    config = fields.Dict(fields.String(), fields.Raw(allow_none=True))
+
+    @pre_load
+    def rename_fields(  # pylint: disable=unused-argument
+        self,
+        data: Dict[str, Any],
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        Handle keys that can have camelCase or snake_case and Core/Cloud differences.
+        """
+        if "uniqueId" in data:
+            data["unique_id"] = data.pop("uniqueId")
+
+        if "childrenL1" in data:
+            data["children"] = data.pop("childrenL1")
+
+        if isinstance(columns := data.get("columns"), dict):
+            data["columns"] = list(columns.values())
+
+        if "dependsOn" in data:
+            data["depends_on"] = data.pop("dependsOn")
+        depends_on = data.get("depends_on", [])
+
+        if isinstance(depends_on, dict):
+            data["depends_on"] = depends_on["nodes"]
+
+        parse_meta_properties(data)
+
+        return data
+
+
+class FilterSchema(PostelSchema):
+    """
+    Schema for a metric filter.
+    """
+
+    field = fields.String()
+    operator = fields.String()
+    value = fields.String()
+
+
+class MetricSchema(PostelSchema):
+    """
+    Base schema for a dbt metric.
+    """
+
+    name = fields.String()
+    label = fields.String()
+    description = fields.String()
+    meta = fields.Raw()
+    superset_meta = fields.Raw()
+
+    @pre_load
+    def pre_load_process(  # pylint: disable=unused-argument
+        self,
+        data: Dict[str, Any],
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        Parse the meta properties.
+        """
+        parse_meta_properties(data)
+        return data
+
+
+class OGMetricSchema(MetricSchema):
+    """
+    Schema for an OG metric.
+    """
+
+    depends_on = fields.List(fields.String())
+    filters = fields.List(fields.Nested(FilterSchema))
+    sql = fields.String()
+    type = fields.String()
+    unique_id = fields.String()
+    # dbt >= 1.3
+    calculation_method = fields.String()
+    expression = fields.String()
+    dialect = fields.String()
+    skip_parsing = fields.Boolean(allow_none=True)
+
+    @pre_load
+    def pre_load_process(  # pylint: disable=unused-argument
+        self,
+        data: Dict[str, Any],
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        Handle keys that can have camelCase or snake_case and Core/Cloud differences.
+        """
+        # Metric being loaded directly as OGMetric
+        if "superset_meta" not in data:
+            parse_meta_properties(data)
+
+        if "uniqueId" in data:
+            data["unique_id"] = data.pop("uniqueId")
+
+        if "dependsOn" in data:
+            data["depends_on"] = data.pop("dependsOn")
+        depends_on = data.get("depends_on", [])
+
+        if isinstance(depends_on, dict):
+            data["depends_on"] = depends_on["nodes"]
+
+        return data
+
+
+class MFMetricType(str, Enum):
+    """
+    Type of the MetricFlow metric.
+    """
+
+    SIMPLE = "SIMPLE"
+    RATIO = "RATIO"
+    CUMULATIVE = "CUMULATIVE"
+    DERIVED = "DERIVED"
+
+
+class MFMetricSchema(MetricSchema):
+    """
+    Schema for a MetricFlow metric.
+    """
+
+    type = PostelEnumField(MFMetricType)
+
+
+class MFSQLEngine(str, Enum):
+    """
+    Databases supported by MetricFlow.
+    """
+
+    BIGQUERY = "BIGQUERY"
+    DUCKDB = "DUCKDB"
+    REDSHIFT = "REDSHIFT"
+    POSTGRES = "POSTGRES"
+    SNOWFLAKE = "SNOWFLAKE"
+    DATABRICKS = "DATABRICKS"
+
+
+class MFMetricWithSQLSchema(MFMetricSchema):
+    """
+    MetricFlow metric with dialect and SQL, as well as model.
+    """
+
+    sql = fields.String()
+    dialect = PostelEnumField(MFSQLEngine)
+    model = fields.String()

--- a/tests/api/clients/dbt_test.py
+++ b/tests/api/clients/dbt_test.py
@@ -12,13 +12,9 @@ from pytest_mock import MockerFixture
 from requests_mock.mocker import Mocker
 from yarl import URL
 
-from preset_cli.api.clients.dbt import (
-    DBTClient,
-    ModelSchema,
-    PostelEnumField,
-    get_custom_urls,
-)
+from preset_cli.api.clients.dbt import DBTClient, get_custom_urls
 from preset_cli.auth.main import Auth
+from preset_cli.cli.superset.sync.dbt.schemas import ModelSchema, PostelEnumField
 
 
 def test_postel_enum_field() -> None:
@@ -888,7 +884,8 @@ def test_dbt_client_get_models(mocker: MockerFixture) -> None:
             "schema": "dbt_beto",
             "unique_id": "model.jaffle_shop.customers",
             "description": "One record per customer",
-            "meta": {"superset": {"cache_timeout": 600}},
+            "meta": {},
+            "superset_meta": {"cache_timeout": 600},
             "database": "dbt-tutorial-347100",
             "name": "customers",
         },
@@ -897,6 +894,7 @@ def test_dbt_client_get_models(mocker: MockerFixture) -> None:
             "unique_id": "model.jaffle_shop.stg_customers",
             "description": "This model cleans up customer data",
             "meta": {},
+            "superset_meta": {},
             "database": "dbt-tutorial-347100",
             "name": "stg_customers",
         },
@@ -905,6 +903,7 @@ def test_dbt_client_get_models(mocker: MockerFixture) -> None:
             "unique_id": "model.jaffle_shop.stg_orders",
             "description": "This model cleans up order data",
             "meta": {},
+            "superset_meta": {},
             "database": "dbt-tutorial-347100",
             "name": "stg_orders",
         },
@@ -913,6 +912,7 @@ def test_dbt_client_get_models(mocker: MockerFixture) -> None:
             "unique_id": "model.metrics.dbt_metrics_default_calendar",
             "description": "",
             "meta": {},
+            "superset_meta": {},
             "database": "dbt-tutorial-347100",
             "name": "dbt_metrics_default_calendar",
         },
@@ -954,6 +954,7 @@ def test_dbt_client_get_og_metrics(mocker: MockerFixture) -> None:
     assert client.get_og_metrics(108380) == [
         {
             "meta": {},
+            "superset_meta": {},
             "name": "new_customers",
             "type": "count",
             "label": "New Customers",
@@ -1008,6 +1009,7 @@ def test_dbt_client_get_og_metrics_versionless_jobs(mocker: MockerFixture) -> No
     assert client.get_og_metrics(108380) == [
         {
             "meta": {},
+            "superset_meta": {},
             "name": "new_customers",
             "type": "count",
             "label": "New Customers",
@@ -1139,7 +1141,13 @@ def test_dbt_client_get_sl_metrics(mocker: MockerFixture) -> None:
     client = DBTClient(auth)
 
     assert client.get_sl_metrics(108380) == [
-        {"name": "a", "description": "A", "type": "SIMPLE"},
+        {
+            "name": "a",
+            "description": "A",
+            "type": "SIMPLE",
+            "meta": {},
+            "superset_meta": {},
+        },
     ]
 
 

--- a/tests/cli/superset/sync/dbt/command_test.py
+++ b/tests/cli/superset/sync/dbt/command_test.py
@@ -17,12 +17,17 @@ from click.testing import CliRunner
 from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest_mock import MockerFixture
 
-from preset_cli.api.clients.dbt import MFSQLEngine, ModelSchema
 from preset_cli.cli.superset.main import superset_cli
 from preset_cli.cli.superset.sync.dbt.command import (
     get_account_id,
     get_job,
     get_project_id,
+)
+from preset_cli.cli.superset.sync.dbt.schemas import (
+    MFMetricSchema,
+    MFSQLEngine,
+    ModelSchema,
+    OGMetricSchema,
 )
 from preset_cli.exceptions import CLIError, DatabaseNotFoundError
 
@@ -33,6 +38,8 @@ with open(os.path.join(dirname, "manifest-metricflow.json"), encoding="utf-8") a
     manifest_metricflow_contents = fp.read()
 
 model_schema = ModelSchema()
+mf_metric_schema = MFMetricSchema()
+og_metric_schema = OGMetricSchema()
 
 
 profiles_contents = yaml.dump(
@@ -168,39 +175,59 @@ dbt_cloud_models = [
 ]
 
 dbt_cloud_metrics = [
-    {
-        "depends_on": ["model.superset_examples.messages_channels"],
-        "description": "",
-        "filters": [],
-        "label": "",
-        "meta": {},
-        "name": "cnt",
-        "sql": "*",
-        "type": "count",
-        "unique_id": "metric.superset_examples.cnt",
-    },
-    {
-        "depends_on": ["a", "b"],
-        "description": "",
-        "filters": [],
-        "label": "",
-        "meta": {},
-        "name": "multiple parents",
-        "sql": "*",
-        "type": "count",
-        "unique_id": "c",
-    },
+    og_metric_schema.load(
+        {
+            "depends_on": ["model.superset_examples.messages_channels"],
+            "description": "",
+            "filters": [],
+            "label": "",
+            "meta": {},
+            "name": "cnt",
+            "sql": "*",
+            "type": "count",
+            "unique_id": "metric.superset_examples.cnt",
+        },
+    ),
+    og_metric_schema.load(
+        {
+            "depends_on": ["a", "b"],
+            "description": "",
+            "filters": [],
+            "label": "",
+            "meta": {},
+            "name": "multiple parents",
+            "sql": "*",
+            "type": "count",
+            "unique_id": "c",
+        },
+    ),
 ]
 
 dbt_metricflow_metrics = [
-    {"name": "a", "type": "Simple", "description": "The simplest metric", "label": "A"},
-    {
-        "name": "b",
-        "type": "derived",
-        "description": "Too complex for Superset",
-        "label": "B",
-    },
-    {"name": "c", "type": "derived", "description": "Multiple models", "label": "C"},
+    mf_metric_schema.load(
+        {
+            "name": "a",
+            "type": "Simple",
+            "description": "The simplest metric",
+            "label": "A",
+        },
+    ),
+    mf_metric_schema.load(
+        {
+            "name": "b",
+            "type": "derived",
+            "description": "Too complex for Superset",
+            "label": "B",
+        },
+    ),
+    mf_metric_schema.load(
+        {
+            "name": "c",
+            "type": "derived",
+            "description": "Multiple models",
+            "label": "C",
+        },
+    ),
 ]
 
 

--- a/tests/cli/superset/sync/dbt/metrics_test.py
+++ b/tests/cli/superset/sync/dbt/metrics_test.py
@@ -9,11 +9,6 @@ from typing import Dict
 import pytest
 from pytest_mock import MockerFixture
 
-from preset_cli.api.clients.dbt import (
-    MFMetricWithSQLSchema,
-    MFSQLEngine,
-    OGMetricSchema,
-)
 from preset_cli.cli.superset.sync.dbt.exposures import ModelKey
 from preset_cli.cli.superset.sync.dbt.metrics import (
     convert_metric_flow_to_superset,
@@ -24,6 +19,11 @@ from preset_cli.cli.superset.sync.dbt.metrics import (
     get_models_from_sql,
     get_superset_metrics_per_model,
     replace_metric_syntax,
+)
+from preset_cli.cli.superset.sync.dbt.schemas import (
+    MFMetricWithSQLSchema,
+    MFSQLEngine,
+    OGMetricSchema,
 )
 
 
@@ -107,7 +107,7 @@ def test_get_metric_expression() -> None:
         get_metric_expression("four", metrics)
     assert str(excinfo.value) == (
         "Unable to generate metric expression from: "
-        "{'dialect': 'postgres', 'sql': 'user_id', 'type': 'hllsketch'}"
+        "{'dialect': 'postgres', 'meta': {}, 'sql': 'user_id', 'superset_meta': {}, 'type': 'hllsketch'}"
     )
 
     with pytest.raises(Exception) as excinfo:


### PR DESCRIPTION
dbt is moving the `meta` properly (previously a top-level property) to inside the `config` property:
* https://docs.getdbt.com/reference/deprecations#propertymovedtoconfigdeprecation
* https://github.com/dbt-labs/dbt-core/issues/11651
* https://docs.getdbt.com/reference/resource-configs/meta

This PR adds support for this change (backwards compatibility should be preserved).