### PR TITLE
feat: export roles when exporting users

### DIFF
--- a/src/preset_cli/api/clients/preset.py
+++ b/src/preset_cli/api/clients/preset.py
@@ -31,7 +31,6 @@ class Role(int, Enum):
 
 
 class PresetClient:  # pylint: disable=too-few-public-methods
-
     """
     A client for the Preset API.
     """
@@ -157,13 +156,13 @@ class PresetClient:  # pylint: disable=too-few-public-methods
             team_members: List[UserType] = [
                 {
                     "id": 0,
-                    "username": payload["user"]["username"],
-                    "role": [],  # TODO (betodealmeida)
-                    "first_name": payload["user"]["first_name"],
-                    "last_name": payload["user"]["last_name"],
-                    "email": payload["user"]["email"].lower(),
+                    "username": element["user"]["username"],
+                    "role": [element["workspace_role"]["role_identifier"]],
+                    "first_name": element["user"]["first_name"],
+                    "last_name": element["user"]["last_name"],
+                    "email": element["user"]["email"].lower(),
                 }
-                for payload in payload["payload"]
+                for element in payload["payload"]
             ]
             workspace_membership.extend(team_members)
 

--- a/tests/api/clients/preset_test.py
+++ b/tests/api/clients/preset_test.py
@@ -101,6 +101,10 @@ def test_preset_client_export_users(requests_mock: Mocker) -> None:
                         "last_name": "Doe",
                         "email": "adoe@example.com",
                     },
+                    "workspace_role": {
+                        "name": "Limited Contributor",
+                        "role_identifier": "PresetGamma",
+                    },
                 },
                 {
                     "user": {
@@ -108,6 +112,10 @@ def test_preset_client_export_users(requests_mock: Mocker) -> None:
                         "first_name": "Bob",
                         "last_name": "Doe",
                         "email": "bdoe@example.com",
+                    },
+                    "workspace_role": {
+                        "name": "Limited Contributor",
+                        "role_identifier": "PresetGamma",
                     },
                 },
             ],
@@ -126,6 +134,10 @@ def test_preset_client_export_users(requests_mock: Mocker) -> None:
                         "first_name": "Clarisse",
                         "last_name": "Doe",
                         "email": "cdoe@example.com",
+                    },
+                    "workspace_role": {
+                        "name": "Limited Contributor",
+                        "role_identifier": "PresetGamma",
                     },
                 },
             ],
@@ -167,7 +179,7 @@ def test_preset_client_export_users(requests_mock: Mocker) -> None:
             "last_name": "Doe",
             "username": "adoe",
             "email": "adoe@example.com",
-            "role": [],
+            "role": ["PresetGamma"],
         },
         {
             "id": 2,
@@ -175,7 +187,7 @@ def test_preset_client_export_users(requests_mock: Mocker) -> None:
             "last_name": "Doe",
             "username": "bdoe",
             "email": "bdoe@example.com",
-            "role": [],
+            "role": ["PresetGamma"],
         },
     ]
 

--- a/tests/api/clients/superset_test.py
+++ b/tests/api/clients/superset_test.py
@@ -1,6 +1,7 @@
 """
 Tests for ``preset_cli.api.clients.superset``.
 """
+
 # pylint: disable=too-many-lines, trailing-whitespace, line-too-long, use-implicit-booleaness-not-comparison
 
 import json
@@ -16,7 +17,6 @@ from pytest_mock import MockerFixture
 from requests_mock.mocker import Mocker
 from yarl import URL
 
-from preset_cli import __version__
 from preset_cli.api.clients.superset import (
     RoleType,
     RuleType,
@@ -1891,6 +1891,10 @@ def test_export_users_preset(requests_mock: Mocker) -> None:
                         "last_name": "Doe",
                         "email": "adoe@example.com",
                     },
+                    "workspace_role": {
+                        "name": "Limited Contributor",
+                        "role_identifier": "PresetGamma",
+                    },
                 },
                 {
                     "user": {
@@ -1898,6 +1902,10 @@ def test_export_users_preset(requests_mock: Mocker) -> None:
                         "first_name": "Bob",
                         "last_name": "Doe",
                         "email": "BDoe@example.com",
+                    },
+                    "workspace_role": {
+                        "name": "Limited Contributor",
+                        "role_identifier": "PresetGamma",
                     },
                 },
             ],
@@ -1917,6 +1925,10 @@ def test_export_users_preset(requests_mock: Mocker) -> None:
                         "first_name": "Clarisse",
                         "last_name": "Doe",
                         "email": "cdoe@example.com",
+                    },
+                    "workspace_role": {
+                        "name": "Limited Contributor",
+                        "role_identifier": "PresetGamma",
                     },
                 },
             ],
@@ -1972,7 +1984,7 @@ def test_export_users_preset(requests_mock: Mocker) -> None:
             "last_name": "Doe",
             "username": "adoe",
             "email": "adoe@example.com",
-            "role": [],
+            "role": ["PresetGamma"],
         },
         {
             "id": 2,
@@ -1980,7 +1992,7 @@ def test_export_users_preset(requests_mock: Mocker) -> None:
             "last_name": "Doe",
             "username": "bdoe",
             "email": "bdoe@example.com",
-            "role": [],
+            "role": ["PresetGamma"],
         },
         {
             "id": 3,
@@ -1988,7 +2000,7 @@ def test_export_users_preset(requests_mock: Mocker) -> None:
             "last_name": "Doe",
             "username": "cdoe",
             "email": "cdoe@example.com",
-            "role": [],
+            "role": ["PresetGamma"],
         },
     ]
 


### PR DESCRIPTION
Export roles when exporting users:

```bash
% preset-cli superset export-users
```

Generates:

```yaml
- email: preset@aircfo.com
  first_name: air
  last_name: CFO
  role:
  - PresetReportsOnly
  username: auth0|68519b4611d426a12318b202
- email: beto@preset.io
  first_name: Beto
  last_name: Ferreira De Almeida
  role:
  - Admin
  username: google-oauth2|109776273413364790889
- email: bri@preset.io
  first_name: Brian
  last_name: Dinapo
  role:
  - PresetAlpha
  username: auth0|61b91a5264eb090076cd90a7
```