### PR TITLE
feat: Local overwrite based on uuid

### DIFF
--- a/src/preset_cli/cli/superset/export.py
+++ b/src/preset_cli/cli/superset/export.py
@@ -89,12 +89,11 @@ def check_asset_uniqueness(  # pylint: disable=too-many-arguments
     Check if the asset is new to the directory or not.
     """
     # First validate by file name
-    if file_path.exists() and not overwrite:
-        raise Exception(
-            f"File already exists and ``--overwrite`` was not specified: {file_path}",
-        )
-    # Short circuit as file will be automatically overwritten based on its filename
     if file_path.exists():
+        if not overwrite:
+            raise Exception(
+                f"File already exists and ``--overwrite`` was not specified: {file_path}",
+            )
         return
 
     # Alternatively, validate by UUID


### PR DESCRIPTION
The export command validates if the exported assets already exist in the target directory, raising if any asset already exists and the `overwrite` flag is not included. The current validation is solely based on the file name, which is not ideal as assets can be renamed in Superset, leading to duplicated files in the directory, and causing a race condition during import (the one imported last reflects in the UI).

This PR updates the logic to first check by file name, and then checks by `uuid`.