### PR TITLE
fix: SQL execution

### DIFF
--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -277,7 +277,6 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
         data = {
             "client_id": shortid()[:10],
             "database_id": database_id,
-            "json": True,
             "runAsync": False,
             "schema": schema,
             "sql": sql,

--- a/tests/api/clients/superset_test.py
+++ b/tests/api/clients/superset_test.py
@@ -91,7 +91,6 @@ def test_run_query(mocker: MockerFixture, requests_mock: Mocker) -> None:
         """{
     "client_id": "5b8f4d8c89",
     "database_id": 1,
-    "json": true,
     "runAsync": false,
     "schema": null,
     "sql": "SELECT 1 AS value",
@@ -178,7 +177,6 @@ def test_run_query_legacy_endpoint(
         """{
     "client_id": "5b8f4d8c89",
     "database_id": 1,
-    "json": true,
     "runAsync": false,
     "schema": null,
     "sql": "SELECT 1 AS value",
@@ -199,7 +197,6 @@ def test_run_query_legacy_endpoint(
         """{
     "client_id": "5b8f4d8c89",
     "database_id": 1,
-    "json": true,
     "runAsync": false,
     "schema": null,
     "sql": "SELECT 1 AS value",


### PR DESCRIPTION
SQL execution was failing with below error:
```
{"message":{"json":["Unknown field."]}}                     
```

The CLI was always including `json:true` in the API payload, however this field was removed from Superset [here](https://github.com/apache/superset/pull/35065). Apparently this field wasn't used as well, so we can safely remove here and it should be backwards compatible.