### PR TITLE
chore(export-users): Standardize team selection for export_users command

### DIFF
--- a/src/preset_cli/cli/export_users.py
+++ b/src/preset_cli/cli/export_users.py
@@ -11,7 +11,7 @@ import click
 import yaml
 
 from preset_cli.api.clients.preset import PresetClient
-from preset_cli.lib import raise_cli_errors
+from preset_cli.lib import raise_cli_errors, split_comma
 
 _logger = logging.getLogger(__name__)
 
@@ -344,13 +344,13 @@ def write_users_to_file(users_list: List[Dict[str, Any]], path: str) -> None:
     type=click.Path(resolve_path=True),
     default="users_workspace_roles.yaml",
 )
-@click.option("--teams", multiple=True, help="Specific teams to export (optional)")
+@click.option("--teams", callback=split_comma)
 @click.pass_context
 @raise_cli_errors
 def export_users(
     ctx: click.core.Context,
     path: str,
-    teams: tuple,
+    teams: List[str],
 ) -> None:
     """
     Export users and their roles for all workspaces.
@@ -358,9 +358,15 @@ def export_users(
     This command exports a YAML file containing user information
     and their roles in each workspace across all teams.
     """
+    # pylint: disable=import-outside-toplevel, cyclic-import
+    from preset_cli.cli.main import get_teams
+
     auth = ctx.obj["AUTH"]
     manager_url = ctx.obj["MANAGER_URL"]
     client = PresetClient(manager_url, auth)
+
+    if not teams:
+        teams = get_teams(client)
 
     # Get filtered teams
     filtered_teams = get_filtered_teams(client, set(teams))

--- a/tests/cli/export_users_test.py
+++ b/tests/cli/export_users_test.py
@@ -31,8 +31,8 @@ def test_export_users_no_teams(mocker: MockerFixture) -> None:
             obj={"AUTH": Mock(), "MANAGER_URL": "https://api.preset.io/"},
         )
 
-    assert result.exit_code == 0
-    assert "No teams found." in result.output
+    assert result.exit_code == 1
+    assert "No teams available" in result.output
 
 
 def test_export_users_with_team_filter(mocker: MockerFixture) -> None:
@@ -55,7 +55,7 @@ def test_export_users_with_team_filter(mocker: MockerFixture) -> None:
     with runner.isolated_filesystem():
         result = runner.invoke(
             export_users,
-            ["--teams", "team1", "--teams", "Team Three", "output.yaml"],
+            ["--teams", "team1,Team Three", "output.yaml"],
             obj={"AUTH": Mock(), "MANAGER_URL": "https://api.preset.io/"},
         )
 
@@ -69,6 +69,39 @@ def test_export_users_with_team_filter(mocker: MockerFixture) -> None:
         with open("output.yaml", "r", encoding="utf-8") as file:
             data = yaml.safe_load(file)
             assert data == []  # No users since we mocked empty responses
+
+
+def test_export_users_prompts_for_teams(mocker: MockerFixture) -> None:
+    """
+    Test export_users prompts for teams when ``--teams`` isn't provided.
+    """
+    runner = CliRunner()
+
+    mock_client = MagicMock()
+    mock_client.get_teams.return_value = [
+        {"name": "team1", "title": "Team One"},
+        {"name": "team2", "title": "Team Two"},
+        {"name": "team3", "title": "Team Three"},
+    ]
+    mock_client.get_team_members.return_value = []
+    mock_client.get_workspaces.return_value = []
+
+    mocker.patch("preset_cli.cli.export_users.PresetClient", return_value=mock_client)
+    # prompt is handled by ``get_teams`` in ``preset_cli.cli.main``
+    mocker.patch("preset_cli.cli.main.input", side_effect=["1,3"])
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            export_users,
+            ["output.yaml"],
+            obj={"AUTH": Mock(), "MANAGER_URL": "https://api.preset.io/"},
+        )
+
+        assert result.exit_code == 0
+        assert "Choose one or more teams" in result.output
+        assert "Processing team: Team One" in result.output
+        assert "Processing team: Team Three" in result.output
+        assert "Processing team: Team Two" not in result.output
 
 
 def test_export_users_full_flow(mocker: MockerFixture) -> None:
@@ -423,7 +456,11 @@ def test_export_users_default_filename(mocker: MockerFixture) -> None:
     runner = CliRunner()
 
     mock_client = MagicMock()
-    mock_client.get_teams.return_value = []
+    mock_client.get_teams.return_value = [
+        {"name": "team1", "title": "Team One"},
+    ]
+    mock_client.get_team_members.return_value = []
+    mock_client.get_workspaces.return_value = []
 
     mocker.patch("preset_cli.cli.export_users.PresetClient", return_value=mock_client)
 
@@ -436,7 +473,7 @@ def test_export_users_default_filename(mocker: MockerFixture) -> None:
 
         assert result.exit_code == 0
         # The default filename from the command definition
-        assert "No teams found." in result.output
+        assert Path("users_workspace_roles.yaml").exists()
 
 
 def test_export_users_case_sensitive_emails(mocker: MockerFixture) -> None:

--- a/tests/cli/export_users_test.py
+++ b/tests/cli/export_users_test.py
@@ -71,6 +71,31 @@ def test_export_users_with_team_filter(mocker: MockerFixture) -> None:
             assert data == []  # No users since we mocked empty responses
 
 
+def test_export_users_no_matching_teams(mocker: MockerFixture) -> None:
+    """
+    Test export_users when ``--teams`` doesn't match any available team.
+    """
+    runner = CliRunner()
+
+    mock_client = MagicMock()
+    mock_client.get_teams.return_value = [
+        {"name": "team1", "title": "Team One"},
+        {"name": "team2", "title": "Team Two"},
+    ]
+
+    mocker.patch("preset_cli.cli.export_users.PresetClient", return_value=mock_client)
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            export_users,
+            ["--teams", "nonexistent", "output.yaml"],
+            obj={"AUTH": Mock(), "MANAGER_URL": "https://api.preset.io/"},
+        )
+
+    assert result.exit_code == 0
+    assert "No teams found." in result.output
+
+
 def test_export_users_prompts_for_teams(mocker: MockerFixture) -> None:
     """
     Test export_users prompts for teams when ``--teams`` isn't provided.


### PR DESCRIPTION
Small change to adhere to the default method to get teams from other commands. This flow prompts user to input a team if not provided.