### PR TITLE
fix(API): Export roles

### DIFF
--- a/src/preset_cli/api/clients/superset.py
+++ b/src/preset_cli/api/clients/superset.py
@@ -49,9 +49,9 @@ from bs4 import BeautifulSoup
 from yarl import URL
 
 from preset_cli import __version__
-from preset_cli.api.clients.preset import PresetClient
 from preset_cli.api.operators import Equal, In, Operator
 from preset_cli.auth.main import Auth
+from preset_cli.exceptions import SupersetError
 from preset_cli.lib import remove_root, validate_response
 from preset_cli.typing import UserType
 
@@ -59,8 +59,7 @@ _logger = logging.getLogger(__name__)
 
 MAX_PAGE_SIZE = 100
 MAX_IDS_IN_EXPORT = 50
-
-
+PRESET_WORKSPACE_DOMAIN = "preset.io"
 PERMISSION_MAP = {
     "all datasource access on all_datasource_access": "All dataset access",
     "all database access on all_database_access": "All database access",
@@ -75,6 +74,14 @@ SCHEMA_PERMISSION = re.compile(
 DATASET_PERMISSION = re.compile(
     r"datasource access on \[(?P<database_name>.*?)\].\[(?P<dataset_name>.*?)\]\(id:\d+\)",
 )
+
+
+def format_permission(permission: str, view_menu: str) -> str:
+    """
+    Convert the permission name from API responses into human-readable
+    values for role exports.
+    """
+    return f"{permission.replace('_', ' ')} on {view_menu}"
 
 
 class GenericDataType(IntEnum):
@@ -205,6 +212,7 @@ class RoleType(TypedDict):
     name: str
     permissions: List[str]
     users: List[str]
+    groups: List[str]
 
 
 class RuleType(TypedDict):
@@ -750,11 +758,36 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
         """
         self.delete_resource("dashboard", dashboard_id)
 
-    def get_users(self, **kwargs: str) -> List[Any]:
+    def get_users(self, **kwargs: str) -> List[UserType]:
+        """
+        Return users.
+
+        Tries the REST API first (``/api/v1/security/users/``), which works for both
+        Preset Cloud and recent Superset versions. Older Superset instances don't expose
+        this endpoint, so we fall back to crawling the CRUD HTML page. Filtering is only
+        supported for the API path.
+        """
+        try:
+            return self._get_users_api(**kwargs)
+        except SupersetError:
+            return self._get_users_legacy()
+
+    def _get_users_api(self, **kwargs: str) -> List[UserType]:
         """
         Return users, possibly filtered.
         """
-        return self.get_resources("security/users", "id", **kwargs)
+        return [
+            {
+                "id": user["id"],
+                "first_name": user["first_name"],
+                "last_name": user["last_name"],
+                "username": user["username"],
+                "email": user["email"],
+                "role": [role["name"] for role in user.get("roles", [])],
+                # TODO: Include groups as well
+            }
+            for user in self.get_resources("security/users", "id", **kwargs)
+        ]
 
     def get_report(self, report_id: int) -> Any:
         """
@@ -873,33 +906,19 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
         """
         return self.get_resources("rowlevelsecurity", **kwargs)
 
-    def export_users(self) -> Iterator[UserType]:
+    def _is_preset_workspace(self) -> bool:
         """
-        Return all users.
+        Return whether the target is a Preset workspace or a Superset instance.
         """
-        # For on-premise OSS Superset we can fetch the list of users by crawling the
-        # ``/users/list/`` page. For a Preset workspace we need custom logic to talk
-        # to Manager.
-        url = self.baseurl / "users/list/"
-        _logger.debug("GET %s", url)
-        response = self.session.get(url)
-        if response.ok:
-            return self._export_users_superset()
-        return self._export_users_preset()
+        return str(self.baseurl.host).endswith(f".{PRESET_WORKSPACE_DOMAIN}")
 
-    def _export_users_preset(self) -> Iterator[UserType]:
+    def _get_users_legacy(self) -> List[UserType]:
         """
-        Return all users from a Preset workspace.
-        """
-        client = PresetClient(self.preset_baseurl, self.auth)
-        return client.export_users(self.baseurl)
-
-    def _export_users_superset(self) -> Iterator[UserType]:
-        """
-        Return all users from a standalone Superset instance.
+        Return all users from an older Superset instance.
 
         Since this is not exposed via an API we need to crawl the CRUD page.
         """
+        users: List[UserType] = []
         page = 0
         while True:
             params = {
@@ -919,30 +938,108 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
 
             for tr in trs[1:]:  # pylint: disable=invalid-name
                 tds = tr.find_all("td")
-                yield {
-                    "id": int(tds[0].find("a").attrs["href"].split("/")[-1]),
-                    "first_name": tds[1].text,
-                    "last_name": tds[2].text,
-                    "username": tds[3].text,
-                    "email": tds[4].text,
-                    "role": parse_html_array(tds[6].text.strip()),
-                }
+                users.append(
+                    {
+                        "id": int(tds[0].find("a").attrs["href"].split("/")[-1]),
+                        "first_name": tds[1].text,
+                        "last_name": tds[2].text,
+                        "username": tds[3].text,
+                        "email": tds[4].text,
+                        "role": parse_html_array(tds[6].text.strip()),
+                    },
+                )
+        return users
 
-    def export_roles(self) -> Iterator[RoleType]:  # pylint: disable=too-many-locals
+    def export_roles(self) -> List[RoleType]:
         """
         Return all roles.
         """
-        user_email_map = {user["id"]: user["email"] for user in self.export_users()}
+        if self._is_preset_workspace():
+            return self._export_dars_preset()
 
+        try:
+            return self._export_roles_superset()
+        except SupersetError:
+            return self._export_roles_legacy()
+
+    def _export_roles_superset(self) -> List[RoleType]:
+        """
+        Return all roles from a standalone Superset instance via the REST API.
+        """
+        user_email_map = {user["id"]: user["email"] for user in self.get_users()}
+        perm_map = {
+            perm["id"]: format_permission(
+                perm["permission"]["name"],
+                perm["view_menu"]["name"],
+            )
+            for perm in self.get_resources("security/permissions-resources", "id")
+        }
+        group_map = {
+            group["id"]: group["name"]
+            for group in self.get_resources("security/groups", "id")
+        }
+
+        roles: List[RoleType] = []
+        for role in self.get_resources("security/roles/search", "id"):
+            roles.append(
+                {
+                    "name": role["name"],
+                    "permissions": [
+                        perm_map[perm_id]
+                        for perm_id in role["permission_ids"]
+                        if perm_id in perm_map
+                    ],
+                    "users": [
+                        user_email_map[user_id]
+                        for user_id in role["user_ids"]
+                        if user_id in user_email_map
+                    ],
+                    "groups": [
+                        group_map[group_id]
+                        for group_id in role["group_ids"]
+                        if group_id in group_map
+                    ],
+                },
+            )
+        return roles
+
+    def _export_dars_preset(self) -> List[RoleType]:
+        """
+        Return all DARs from a Preset workspace via the DAR API.
+        """
+        user_email_map = {user["id"]: user["email"] for user in self.get_users()}
+        roles: List[RoleType] = []
+        for role in self.get_resources("security/dar", "name"):
+            roles.append(
+                {
+                    "name": role["name"],
+                    "permissions": [
+                        format_permission(perm["permission"], perm["view_menu"])
+                        for perm in role["permissions"]
+                    ],
+                    "users": [
+                        user_email_map[user["id"]]
+                        for user in role["users"]
+                        if user["id"] in user_email_map
+                    ],
+                    "groups": [group["name"] for group in role.get("groups", [])],
+                },
+            )
+        return roles
+
+    def _export_roles_legacy(  # pylint: disable=too-many-locals
+        self,
+    ) -> List[RoleType]:
+        """
+        Return all roles by crawling the CRUD HTML pages (older Superset versions).
+        """
+        user_email_map = {user["id"]: user["email"] for user in self.get_users()}
+        roles: List[RoleType] = []
         page = 0
         while True:
             params = {
-                # Superset
                 "psize_RoleModelView": MAX_PAGE_SIZE,
                 "page_RoleModelView": page,
-                # Preset
-                "psize_DataRoleModelView": MAX_PAGE_SIZE,
-                "page_DataRoleModelView": page,
             }
             url = self.baseurl / "roles/list/"
             page += 1
@@ -984,11 +1081,16 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
                     and int(option.attrs["value"]) in user_email_map
                 ]
 
-                yield {
-                    "name": name,
-                    "permissions": permissions,
-                    "users": users,
-                }
+                roles.append(
+                    {
+                        "name": name,
+                        "permissions": permissions,
+                        "users": users,
+                        # Legacy Superset instances didn't support groups
+                        "groups": [],
+                    },
+                )
+        return roles
 
     def export_rls_legacy(self) -> Iterator[RuleType]:
         """
@@ -1095,7 +1197,7 @@ class SupersetClient:  # pylint: disable=too-many-public-methods
         Note: this only works with Preset workspaces for now, since it translates the
         Superset permissions to the Preset permissions.
         """
-        user_id_map = {user["email"]: user["id"] for user in self.export_users()}
+        user_id_map = {user["email"]: user["id"] for user in self.get_users()}
         user_ids = [
             user_id_map[email] for email in role["users"] if email in user_id_map
         ]

--- a/src/preset_cli/cli/main.py
+++ b/src/preset_cli/cli/main.py
@@ -759,7 +759,7 @@ def sync_all_user_roles_to_team(  # pylint: disable=too-many-locals
         superset_client = SupersetClient(f"https://{workspace_hostname}/", client.auth)
 
         user_id_map = {
-            user["email"]: user["id"] for user in superset_client.export_users()
+            user["email"]: user["id"] for user in superset_client.get_users()
         }
         for data_access_role, user_emails in workspace_data_access_roles.items():
             role_id = superset_client.get_role_id(data_access_role)

--- a/src/preset_cli/cli/superset/export.py
+++ b/src/preset_cli/cli/superset/export.py
@@ -623,7 +623,7 @@ def export_users(
     client = SupersetClient(url, auth, preset_baseurl)
 
     users = [
-        {k: v for k, v in user.items() if k != "id"} for user in client.export_users()
+        {k: v for k, v in user.items() if k != "id"} for user in client.get_users()
     ]
 
     newline = get_newline_char(force_unix_eol)
@@ -747,7 +747,7 @@ def export_ownership(  # pylint: disable=too-many-locals, too-many-arguments
     url = URL(ctx.obj["INSTANCE"])
     client = SupersetClient(url, auth)
 
-    users = {user["id"]: user["email"] for user in client.export_users()}
+    users = {user["id"]: user["email"] for user in client.get_users()}
 
     asset_types = set(asset_type)
     ids = {

--- a/src/preset_cli/cli/superset/import_.py
+++ b/src/preset_cli/cli/superset/import_.py
@@ -93,7 +93,7 @@ def import_ownership(  # pylint: disable=too-many-locals
     with open(path, encoding="utf-8") as input_:
         config = yaml.load(input_, Loader=yaml.SafeLoader)
 
-    users = {user["email"]: user["id"] for user in client.export_users()}
+    users = {user["email"]: user["id"] for user in client.get_users()}
     with open(log_file_path, "w", encoding="utf-8") as log_file:
         for resource_name, resources in config.items():
             resource_ids = {

--- a/tests/api/clients/superset_test.py
+++ b/tests/api/clients/superset_test.py
@@ -1685,16 +1685,37 @@ def test_delete_database(mocker: MockerFixture) -> None:
 
 def test_get_users(mocker: MockerFixture) -> None:
     """
-    Test the ``get_users`` method.
+    Test the ``get_users`` method (REST API path).
     """
     auth = Auth()
     client = SupersetClient("https://superset.example.org/", auth)
-    get_resources = mocker.patch.object(client, "get_resources")
+    get_resources = mocker.patch.object(
+        client,
+        "get_resources",
+        return_value=[
+            {
+                "id": 1,
+                "first_name": "Alice",
+                "last_name": "Doe",
+                "username": "adoe",
+                "email": "adoe@example.com",
+                "roles": [{"id": 1, "name": "Admin"}],
+                "active": True,
+            },
+        ],
+    )
 
-    client.get_users()
+    assert client.get_users() == [
+        {
+            "id": 1,
+            "first_name": "Alice",
+            "last_name": "Doe",
+            "username": "adoe",
+            "email": "adoe@example.com",
+            "role": ["Admin"],
+        },
+    ]
     get_resources.assert_called_with("security/users", "id")
-    client.get_users(username="john")
-    get_resources.assert_called_with("security/users", "id", username="john")
 
 
 def test_get_report(mocker: MockerFixture) -> None:
@@ -1906,11 +1927,16 @@ def test_get_rls(mocker: MockerFixture) -> None:
     get_resources.assert_called_with("rowlevelsecurity")
 
 
-def test_export_users(requests_mock: Mocker) -> None:
+def test_get_users_legacy(requests_mock: Mocker) -> None:
     """
-    Test ``export_users``.
+    Test ``get_users`` falling back to crawling the CRUD HTML page.
     """
-    requests_mock.get("https://superset.example.org/users/list/")
+    # the users API is unavailable on older Superset, so we fall back to the HTML
+    # crawl
+    requests_mock.get(
+        "https://superset.example.org/api/v1/security/users/",
+        status_code=404,
+    )
     requests_mock.get(
         "https://superset.example.org/users/list/?psize_UserDBModelView=100&page_UserDBModelView=0",
         text="""
@@ -1982,7 +2008,7 @@ def test_export_users(requests_mock: Mocker) -> None:
 
     auth = Auth()
     client = SupersetClient("https://superset.example.org/", auth)
-    assert list(client.export_users()) == [
+    assert client.get_users() == [
         {
             "id": 1,
             "first_name": "Alice",
@@ -2002,149 +2028,16 @@ def test_export_users(requests_mock: Mocker) -> None:
     ]
 
 
-def test_export_users_preset(requests_mock: Mocker) -> None:
-    """
-    Test ``export_users``.
-    """
-    requests_mock.get("https://superset.example.org/users/list/", status_code=404)
-    requests_mock.get(
-        "https://api.app.preset.io/v1/teams",
-        json={
-            "payload": [{"name": "team1"}],
-        },
-    )
-    requests_mock.get(
-        "https://api.app.preset.io/v1/teams/team1/workspaces",
-        json={
-            "payload": [{"id": 1, "hostname": "superset.example.org"}],
-        },
-    )
-    requests_mock.get(
-        "https://api.app.preset.io/v1/teams/team1/workspaces/1/memberships?page_number=1&page_size=250",
-        json={
-            "payload": [
-                {
-                    "user": {
-                        "username": "adoe",
-                        "first_name": "Alice",
-                        "last_name": "Doe",
-                        "email": "adoe@example.com",
-                    },
-                    "workspace_role": {
-                        "name": "NoAccess",
-                    },
-                },
-                {
-                    "user": {
-                        "username": "bdoe",
-                        "first_name": "Bob",
-                        "last_name": "Doe",
-                        "email": "BDoe@example.com",
-                    },
-                    "workspace_role": {
-                        "name": "NoAccess",
-                    },
-                },
-            ],
-            "meta": {
-                "count": 251,
-            },
-        },
-    )
-
-    requests_mock.get(
-        "https://api.app.preset.io/v1/teams/team1/workspaces/1/memberships?page_number=2&page_size=250",
-        json={
-            "payload": [
-                {
-                    "user": {
-                        "username": "cdoe",
-                        "first_name": "Clarisse",
-                        "last_name": "Doe",
-                        "email": "cdoe@example.com",
-                    },
-                    "workspace_role": {
-                        "name": "NoAccess",
-                    },
-                },
-            ],
-            "meta": {
-                "count": 251,
-            },
-        },
-    )
-
-    requests_mock.get(
-        "https://superset.example.org/api/v1/chart/related/owners?q=(page:0,page_size:100)",
-        json={
-            "count": 3,
-            "result": [
-                {
-                    "extra": {
-                        "active": True,
-                        "email": "adoe@example.com",
-                    },
-                    "text": "Alice Doe",
-                    "value": 1,
-                },
-                {
-                    "extra": {
-                        "active": True,
-                        "email": "bdoe@example.com",
-                    },
-                    "text": "Bob Doe",
-                    "value": 2,
-                },
-                {
-                    "extra": {
-                        "active": True,
-                        "email": "CDoe@example.com",
-                    },
-                    "text": "Clarisse Doe",
-                    "value": 3,
-                },
-            ],
-        },
-    )
-    requests_mock.get(
-        "https://superset.example.org/api/v1/chart/related/owners?q=(page:1,page_size:100)",
-        json={"count": 3, "result": []},  # empty result to break the loop
-    )
-
-    auth = Auth()
-    client = SupersetClient("https://superset.example.org/", auth)
-    assert list(client.export_users()) == [
-        {
-            "id": 1,
-            "first_name": "Alice",
-            "last_name": "Doe",
-            "username": "adoe",
-            "email": "adoe@example.com",
-            "role": ["noaccess"],
-        },
-        {
-            "id": 2,
-            "first_name": "Bob",
-            "last_name": "Doe",
-            "username": "bdoe",
-            "email": "bdoe@example.com",
-            "role": ["noaccess"],
-        },
-        {
-            "id": 3,
-            "first_name": "Clarisse",
-            "last_name": "Doe",
-            "username": "cdoe",
-            "email": "cdoe@example.com",
-            "role": ["noaccess"],
-        },
-    ]
-
-
 def test_export_roles(mocker: MockerFixture, requests_mock: Mocker) -> None:
     """
-    Test ``export_roles``.
+    Test ``export_roles`` falling back to crawling the CRUD HTML pages.
     """
+    # a non-preset.io host routes to the Superset API path; failing the API makes
+    # it fall back to the legacy HTML crawl
+    requests_mock.get(
+        "https://superset.example.org/api/v1/security/permissions-resources/",
+        status_code=500,
+    )
     requests_mock.get(
         (
             "https://superset.example.org/roles/list/?"
@@ -2249,7 +2142,7 @@ def test_export_roles(mocker: MockerFixture, requests_mock: Mocker) -> None:
     )
     mocker.patch.object(
         SupersetClient,
-        "export_users",
+        "get_users",
         return_value=[
             {"id": 1, "email": "adoe@example.com"},
             {"id": 2, "email": "bdoe@example.com"},
@@ -2263,11 +2156,13 @@ def test_export_roles(mocker: MockerFixture, requests_mock: Mocker) -> None:
             "name": "Admin",
             "permissions": ["can this", "can that"],
             "users": ["adoe@example.com"],
+            "groups": [],
         },
         {
             "name": "Public",
             "permissions": [],
             "users": [],
+            "groups": [],
         },
     ]
 
@@ -2277,8 +2172,14 @@ def test_export_roles_anchor_role_id(
     requests_mock: Mocker,
 ) -> None:
     """
-    Test ``export_roles``.
+    Test ``export_roles`` legacy crawl when role IDs come from anchor links.
     """
+    # a non-preset.io host routes to the Superset API path; failing the API makes
+    # it fall back to the legacy HTML crawl
+    requests_mock.get(
+        "https://superset.example.org/api/v1/security/permissions-resources/",
+        status_code=500,
+    )
     requests_mock.get(
         (
             "https://superset.example.org/roles/list/?"
@@ -2383,7 +2284,7 @@ def test_export_roles_anchor_role_id(
     )
     mocker.patch.object(
         SupersetClient,
-        "export_users",
+        "get_users",
         return_value=[
             {"id": 1, "email": "adoe@example.com"},
             {"id": 2, "email": "bdoe@example.com"},
@@ -2397,13 +2298,199 @@ def test_export_roles_anchor_role_id(
             "name": "Admin",
             "permissions": ["can this", "can that"],
             "users": ["adoe@example.com"],
+            "groups": [],
         },
         {
             "name": "Public",
             "permissions": [],
             "users": [],
+            "groups": [],
         },
     ]
+
+
+def test_export_roles_superset_api(
+    mocker: MockerFixture,
+    requests_mock: Mocker,
+) -> None:
+    """
+    Test ``export_roles`` against a standalone Superset via the REST API.
+    """
+    # a non-preset.io host routes to the Superset API path
+    mocker.patch.object(
+        SupersetClient,
+        "get_users",
+        return_value=[
+            {"id": 1, "email": "adoe@example.com"},
+            {"id": 2, "email": "bdoe@example.com"},
+        ],
+    )
+    requests_mock.get(
+        "https://superset.example.org/api/v1/security/permissions-resources/?q="
+        "(filters:!(),order_column:id,order_direction:desc,page:0,page_size:100)",
+        json={
+            "result": [
+                {
+                    "id": 1,
+                    "permission": {"name": "can_read"},
+                    "view_menu": {"name": "Chart"},
+                },
+                {
+                    "id": 2,
+                    "permission": {"name": "can_write"},
+                    "view_menu": {"name": "Chart"},
+                },
+            ],
+        },
+    )
+    requests_mock.get(
+        "https://superset.example.org/api/v1/security/permissions-resources/?q="
+        "(filters:!(),order_column:id,order_direction:desc,page:1,page_size:100)",
+        json={"result": []},
+    )
+    requests_mock.get(
+        "https://superset.example.org/api/v1/security/groups/?q="
+        "(filters:!(),order_column:id,order_direction:desc,page:0,page_size:100)",
+        json={"result": [{"id": 10, "name": "Data Team"}]},
+    )
+    requests_mock.get(
+        "https://superset.example.org/api/v1/security/groups/?q="
+        "(filters:!(),order_column:id,order_direction:desc,page:1,page_size:100)",
+        json={"result": []},
+    )
+    requests_mock.get(
+        "https://superset.example.org/api/v1/security/roles/search/?q="
+        "(filters:!(),order_column:id,order_direction:desc,page:0,page_size:100)",
+        json={
+            "result": [
+                {
+                    "id": 1,
+                    "name": "Admin",
+                    "user_ids": [1],
+                    "group_ids": [10],
+                    "permission_ids": [1, 2],
+                },
+                {
+                    "id": 2,
+                    "name": "Public",
+                    "user_ids": [],
+                    "group_ids": [],
+                    "permission_ids": [],
+                },
+            ],
+        },
+    )
+    requests_mock.get(
+        "https://superset.example.org/api/v1/security/roles/search/?q="
+        "(filters:!(),order_column:id,order_direction:desc,page:1,page_size:100)",
+        json={"result": []},
+    )
+
+    auth = Auth()
+    client = SupersetClient("https://superset.example.org/", auth)
+    assert list(client.export_roles()) == [
+        {
+            "name": "Admin",
+            "permissions": ["can read on Chart", "can write on Chart"],
+            # direct members only; group assignment is exported as a name
+            "users": ["adoe@example.com"],
+            "groups": ["Data Team"],
+        },
+        {
+            "name": "Public",
+            "permissions": [],
+            "users": [],
+            "groups": [],
+        },
+    ]
+
+
+def test_export_roles_preset_api(
+    mocker: MockerFixture,
+    requests_mock: Mocker,
+) -> None:
+    """
+    Test ``export_roles`` against a Preset workspace via the ``dar`` API.
+    """
+    # a ``*.preset.io`` host routes to the Preset DAR path
+    mocker.patch.object(
+        SupersetClient,
+        "get_users",
+        return_value=[{"id": 10, "email": "vitor@example.com"}],
+    )
+    requests_mock.get(
+        "https://abc123.app.preset.io/api/v1/security/dar/?q="
+        "(filters:!(),order_column:name,order_direction:desc,page:0,page_size:100)",
+        json={
+            "result": [
+                {
+                    "id": 37,
+                    "name": "rls_test",
+                    "permissions": [
+                        {
+                            "id": 214,
+                            "name": "All database access",
+                            "permission": "all_database_access",
+                            "view_menu": "all_database_access",
+                        },
+                    ],
+                    "users": [{"id": 10, "name": "Vitor", "username": "vitor"}],
+                    "groups": [{"id": 5, "name": "Analysts"}],
+                },
+                {
+                    "id": 38,
+                    "name": "empty",
+                    "permissions": [],
+                    "users": [],
+                    "groups": [],
+                },
+            ],
+        },
+    )
+    requests_mock.get(
+        "https://abc123.app.preset.io/api/v1/security/dar/?q="
+        "(filters:!(),order_column:name,order_direction:desc,page:1,page_size:100)",
+        json={"result": []},
+    )
+
+    auth = Auth()
+    client = SupersetClient("https://abc123.app.preset.io/", auth)
+    assert client.export_roles() == [
+        {
+            "name": "rls_test",
+            "permissions": ["all database access on all_database_access"],
+            "users": ["vitor@example.com"],
+            "groups": ["Analysts"],
+        },
+        {
+            "name": "empty",
+            "permissions": [],
+            "users": [],
+            "groups": [],
+        },
+    ]
+
+
+def test_is_preset_workspace() -> None:
+    """
+    Test ``_is_preset_workspace`` hostname detection.
+    """
+    auth = Auth()
+
+    def is_preset(baseurl: str) -> bool:
+        # pylint: disable=protected-access
+        return SupersetClient(baseurl, auth)._is_preset_workspace()
+
+    # Preset Cloud workspaces (prod and non-prod) are served from ``*.preset.io``
+    assert is_preset("https://87eb76e3.us2a.app.preset.io/") is True
+    assert is_preset("https://abc123.app-stg.preset.io/") is True
+
+    # standalone Superset instances are not
+    assert is_preset("http://10.33.92.175:9787/analytics/") is False
+    assert is_preset("https://superset.example.org/") is False
+    # look-alike hosts must not be treated as Preset
+    assert is_preset("https://notpreset.io.evil.com/") is False
+    assert is_preset("https://evilpreset.io/") is False
 
 
 def test_export_rls_legacy(requests_mock: Mocker) -> None:
@@ -2940,7 +3027,7 @@ def test_import_role(mocker: MockerFixture, requests_mock: Mocker) -> None:
     )
     mocker.patch.object(
         SupersetClient,
-        "export_users",
+        "get_users",
         return_value=[
             {"id": 1, "email": "admin@example.com"},
             {"id": 2, "email": "adoe@example.com"},
@@ -2957,6 +3044,7 @@ def test_import_role(mocker: MockerFixture, requests_mock: Mocker) -> None:
             "datasource access on [Not added].[nope](id:42)",
         ],
         "users": ["admin@example.com", "adoe@example.com", "bdoe@example.com"],
+        "groups": [],
     }
 
     auth = Auth()
@@ -3063,7 +3151,7 @@ def test_import_role_update(mocker: MockerFixture, requests_mock: Mocker) -> Non
     )
     mocker.patch.object(
         SupersetClient,
-        "export_users",
+        "get_users",
         return_value=[
             {"id": 1, "email": "admin@example.com"},
             {"id": 2, "email": "adoe@example.com"},
@@ -3080,6 +3168,7 @@ def test_import_role_update(mocker: MockerFixture, requests_mock: Mocker) -> Non
             "datasource access on [Not added].[nope](id:42)",
         ],
         "users": ["admin@example.com", "adoe@example.com", "bdoe@example.com"],
+        "groups": [],
     }
 
     auth = Auth()

--- a/tests/cli/main_test.py
+++ b/tests/cli/main_test.py
@@ -1436,7 +1436,7 @@ def test_sync_all_user_roles_to_team(mocker: MockerFixture) -> None:
     ]
     SupersetClient = mocker.patch("preset_cli.cli.main.SupersetClient")
     superset_client = SupersetClient()
-    superset_client.export_users.return_value = [
+    superset_client.get_users.return_value = [
         {"email": "adoe@example.com", "id": 1},
         {"email": "bdoe@example.com", "id": 2},
     ]
@@ -1496,7 +1496,7 @@ def test_sync_all_user_roles_to_team_workspace_title(mocker: MockerFixture) -> N
     ]
     SupersetClient = mocker.patch("preset_cli.cli.main.SupersetClient")
     superset_client = SupersetClient()
-    superset_client.export_users.return_value = [
+    superset_client.get_users.return_value = [
         {"email": "adoe@example.com", "id": 1},
         {"email": "bdoe@example.com", "id": 2},
     ]

--- a/tests/cli/superset/export_test.py
+++ b/tests/cli/superset/export_test.py
@@ -623,7 +623,7 @@ def test_export_users(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
     SupersetClient = mocker.patch("preset_cli.cli.superset.export.SupersetClient")
     client = SupersetClient()
-    client.export_users.return_value = [
+    client.get_users.return_value = [
         {
             "first_name": "admin",
             "last_name": "admin",
@@ -664,7 +664,7 @@ def test_export_users_force_unix_eol_enable(
     mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
     SupersetClient = mocker.patch("preset_cli.cli.superset.export.SupersetClient")
     client = SupersetClient()
-    client.export_users.return_value = [
+    client.get_users.return_value = [
         {
             "first_name": "admin",
             "last_name": "admin",
@@ -866,7 +866,7 @@ def test_export_ownership(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
     SupersetClient = mocker.patch("preset_cli.cli.superset.export.SupersetClient")
     client = SupersetClient()
-    client.export_users.return_value = [
+    client.get_users.return_value = [
         {"id": 1, "email": "adoe@example.com"},
         {"id": 2, "email": "bdoe@example.com"},
     ]
@@ -920,7 +920,7 @@ def test_export_ownership_force_unix_eol_enable(
     mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
     SupersetClient = mocker.patch("preset_cli.cli.superset.export.SupersetClient")
     client = SupersetClient()
-    client.export_users.return_value = [
+    client.get_users.return_value = [
         {"id": 1, "email": "adoe@example.com"},
         {"id": 2, "email": "bdoe@example.com"},
     ]
@@ -967,7 +967,7 @@ def test_export_ownership_by_asset_type(
     mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
     SupersetClient = mocker.patch("preset_cli.cli.superset.export.SupersetClient")
     client = SupersetClient()
-    client.export_users.return_value = [
+    client.get_users.return_value = [
         {"id": 1, "email": "adoe@example.com"},
         {"id": 2, "email": "bdoe@example.com"},
     ]
@@ -1039,7 +1039,7 @@ def test_export_ownership_single_asset_type(
     mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
     SupersetClient = mocker.patch("preset_cli.cli.superset.export.SupersetClient")
     client = SupersetClient()
-    client.export_users.return_value = [
+    client.get_users.return_value = [
         {"id": 3, "email": "cdoe@example.com"},
     ]
     client.export_ownership.return_value = [
@@ -2010,7 +2010,7 @@ def test_export_ownership_by_ids(
     mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
     SupersetClient = mocker.patch("preset_cli.cli.superset.export.SupersetClient")
     client = SupersetClient()
-    client.export_users.return_value = [
+    client.get_users.return_value = [
         {"id": 1, "email": "adoe@example.com"},
     ]
     client.export_ownership.side_effect = [
@@ -2081,7 +2081,7 @@ def test_export_ownership_by_ids_and_asset_type(
     mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
     SupersetClient = mocker.patch("preset_cli.cli.superset.export.SupersetClient")
     client = SupersetClient()
-    client.export_users.return_value = [
+    client.get_users.return_value = [
         {"id": 1, "email": "adoe@example.com"},
     ]
     client.export_ownership.return_value = [

--- a/tests/cli/superset/import_test.py
+++ b/tests/cli/superset/import_test.py
@@ -82,7 +82,7 @@ def test_import_ownership(mocker: MockerFixture, fs: FakeFilesystem) -> None:
     SupersetClient = mocker.patch("preset_cli.cli.superset.import_.SupersetClient")
     mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", Path("progress.log"))
     client = SupersetClient()
-    client.export_users.return_value = [{"id": 1, "email": "admin@example.com"}]
+    client.get_users.return_value = [{"id": 1, "email": "admin@example.com"}]
     client.get_uuids.return_value = {1: UUID("e4e6a14b-c3e8-4fdf-a850-183ba6ce15e0")}
     ownership = {
         "dataset": [
@@ -147,7 +147,7 @@ def test_import_ownership_progress_log(
     mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
     SupersetClient = mocker.patch("preset_cli.cli.superset.import_.SupersetClient")
     client = SupersetClient()
-    client.export_users.return_value = [
+    client.get_users.return_value = [
         {"id": 1, "email": "admin@example.com"},
         {"id": 2, "email": "viewer@example.com"},
     ]
@@ -230,7 +230,7 @@ def test_import_ownership_failure(mocker: MockerFixture, fs: FakeFilesystem) -> 
     SupersetClient = mocker.patch("preset_cli.cli.superset.import_.SupersetClient")
     mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", Path("progress.log"))
     client = SupersetClient()
-    client.export_users.return_value = [{"id": 1, "email": "admin@example.com"}]
+    client.get_users.return_value = [{"id": 1, "email": "admin@example.com"}]
     client.get_uuids.return_value = {
         1: UUID("18ddf8ab-68f9-4c15-ba9f-c75921b019e6"),
         2: UUID("18ddf8ab-68f9-4c15-ba9f-c75921b019e7"),
@@ -292,7 +292,7 @@ def test_import_ownership_failure_continue(
     SupersetClient = mocker.patch("preset_cli.cli.superset.import_.SupersetClient")
     mocker.patch("preset_cli.cli.superset.lib.LOG_FILE_PATH", Path("progress.log"))
     client = SupersetClient()
-    client.export_users.return_value = [{"id": 1, "email": "admin@example.com"}]
+    client.get_users.return_value = [{"id": 1, "email": "admin@example.com"}]
     client.get_uuids.return_value = {
         1: UUID("18ddf8ab-68f9-4c15-ba9f-c75921b019e6"),
         2: UUID("18ddf8ab-68f9-4c15-ba9f-c75921b019e7"),


### PR DESCRIPTION
The Roles Export logic was still relying on crawling HTML, which doesn't work for newer Superset versions. This PR introduces the following changes:
* Renamed `export_users` to `get_users`.
* Removed Preset-specific logic to get users from a Workspace context (Preset now supports `/api/v1/security/users/`).
* Kept `_get_users_legacy` to crawl HTML for older Superset instances.
* `export_roles` now relies on either `_export_roles_superset` (via `/api/v1/security/permissions-resources`, `/api/v1/security/groups` and `/api/v1/security/roles/search`) or `_export_dars_preset` (via `/api/v1/security/dar`).
* `_export_roles_legacy` still preserved for older Superset instances.
* Added a helper for `_is_preset_workspace`.